### PR TITLE
feat(rag): add multimodal retrieval units

### DIFF
--- a/mem-knowledge/pyproject.toml
+++ b/mem-knowledge/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "uvicorn[standard]>=0.37,<1",
     "xlrd>=2.0,<3",
     "xxhash>=3.5,<5",
+    "jieba==0.42.1",
 ]
 
 [dependency-groups]

--- a/mem-knowledge/src/api/routes/chunk.py
+++ b/mem-knowledge/src/api/routes/chunk.py
@@ -291,10 +291,17 @@ async def get_chunk(
             document_id,
             principal,
         )
+        resolved_embedding = await chunk_service.resolve_embedding_config(
+            db,
+            snapshot,
+            principal,
+        )
     store = chunk_service.build_chunk_store(
         runtime,
         await runtime.elasticsearch.client(),
         snapshot,
+        resolved_embedding,
+        for_mutation=False,
     )
     chunk = await chunk_service.require_owned_chunk(store, snapshot, doc_id)
     return _success(

--- a/mem-knowledge/src/api/routes/chunk.py
+++ b/mem-knowledge/src/api/routes/chunk.py
@@ -131,10 +131,20 @@ async def get_chunks(
             document_id,
             principal,
         )
+        # Listing must resolve the embedding config so multimodal (unit) indexes
+        # are recognized and collapsed to chunk records; otherwise every unit of
+        # a chunk would surface as a duplicate row.
+        resolved_embedding = await chunk_service.resolve_embedding_config(
+            db,
+            snapshot,
+            principal,
+        )
     store = chunk_service.build_chunk_store(
         runtime,
         await runtime.elasticsearch.client(),
         snapshot,
+        resolved_embedding,
+        for_mutation=False,
     )
     return _success(
         request,

--- a/mem-knowledge/src/rag/knowledge_graph/elasticsearch_store.py
+++ b/mem-knowledge/src/rag/knowledge_graph/elasticsearch_store.py
@@ -10,7 +10,7 @@ from elasticsearch import BadRequestError, NotFoundError
 
 from ...utils.datetime_utils import utcnow_naive
 from ..models.chunk import DocumentChunk
-from ..retrieval.elasticsearch_queries import raise_on_shard_failures
+from ..retrieval.elasticsearch_queries import build_chunk_record_filter, raise_on_shard_failures
 from ..vdb.pit_search import iter_async_search_after_hits
 from .models import (
     AffectedProjectionKeys,
@@ -179,6 +179,7 @@ class GraphElasticsearchStore:
                         {"term": {"metadata.knowledge_id": knowledge_id}},
                         {"term": {"metadata.document_id": document_id}},
                         {"term": {"metadata.status": 1}},
+                        build_chunk_record_filter(),
                     ]
                 }
             },

--- a/mem-knowledge/src/rag/models/retrieval_unit.py
+++ b/mem-knowledge/src/rag/models/retrieval_unit.py
@@ -149,6 +149,10 @@ def build_retrieval_units(
     # Image chunk: text unit uses vision_text (the image's textual form).
     vision_text = metadata.get("vision_text")
     if isinstance(vision_text, str) and vision_text.strip():
+        text_metadata = dict(metadata)
+        # Keep the chunk's original markdown body so recall can return it instead
+        # of the vision caption when this text unit is the hit.
+        text_metadata["original_page_content"] = chunk.page_content
         units.append(
             RetrievalUnit(
                 unit_id=unit_id_for(chunk_id, RetrievalUnitKind.TEXT, 0),
@@ -156,7 +160,7 @@ def build_retrieval_units(
                 return_chunk_id=return_chunk_id,
                 kind=RetrievalUnitKind.TEXT,
                 content=vision_text.strip(),
-                metadata=metadata,
+                metadata=text_metadata,
             )
         )
     for index, asset_id in enumerate(asset_ids):

--- a/mem-knowledge/src/rag/models/retrieval_unit.py
+++ b/mem-knowledge/src/rag/models/retrieval_unit.py
@@ -1,0 +1,186 @@
+"""Retrieval unit contracts for multimodal (qwen3-vl) knowledge bases.
+
+A multimodal chunk is decomposed into independent retrieval units:
+one optional text unit (content = chunk_retrieval_content / vision_text) plus
+one image unit per attached asset. Each unit is embedded and indexed
+independently so that vector recall and rerank operate on units, keeping the
+candidate count aligned with the requested top_n. Units collapse back to their
+source chunk (by ``chunk_id``) after rerank. ``chunk_record`` units carry no
+vector and exist only as the authoritative per-chunk document for listing,
+parent resolution and CRUD; they are excluded from recall.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+from redbear_model import ImageEmbeddingContent
+
+from .chunk import DocumentChunk, chunk_retrieval_content
+
+_UNIT_NAMESPACE = uuid.UUID("6f1c9a2e-7b3a-4f5d-9c2e-1a8b4d6e7f90")
+MAX_IMAGES_PER_CHUNK = 10
+
+
+class RetrievalUnitKind(StrEnum):
+    TEXT = "text"
+    IMAGE = "image"
+    CHUNK_RECORD = "chunk_record"
+
+
+class RetrievalUnit(BaseModel):
+    """One independently embedded/indexed retrieval unit of a chunk."""
+
+    unit_id: str
+    chunk_id: str
+    return_chunk_id: str
+    kind: RetrievalUnitKind
+    unit_index: int = 0
+    asset_file_id: str | None = None
+    content: str = ""
+    metadata: dict = Field(default_factory=dict)
+
+
+def unit_id_for(doc_id: str, kind: RetrievalUnitKind, unit_index: int) -> str:
+    """Stable, idempotent unit id so re-indexing does not duplicate docs."""
+
+    return uuid.uuid5(_UNIT_NAMESPACE, f"{doc_id}:{kind.value}:{unit_index}").hex
+
+
+def _chunk_id(chunk: DocumentChunk) -> str:
+    metadata = chunk.metadata or {}
+    doc_id = metadata.get("doc_id")
+    if doc_id:
+        return str(doc_id)
+    document_id = metadata.get("document_id")
+    sort_id = metadata.get("sort_id")
+    if document_id is not None and sort_id is not None:
+        return f"{document_id}:{sort_id}"
+    return uuid.uuid5(_UNIT_NAMESPACE, f"content:{chunk.page_content}").hex
+
+
+def _return_chunk_id(chunk: DocumentChunk, chunk_id: str) -> str:
+    metadata = chunk.metadata or {}
+    if metadata.get("chunk_type") == "child" and metadata.get("parent_id"):
+        return str(metadata["parent_id"])
+    return chunk_id
+
+
+def _asset_file_ids(chunk: DocumentChunk) -> list[str]:
+    metadata = chunk.metadata or {}
+    raw_ids = metadata.get("asset_file_ids")
+    if not isinstance(raw_ids, list):
+        return []
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in raw_ids:
+        normalized = str(value)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+        if len(result) == MAX_IMAGES_PER_CHUNK:
+            break
+    return result
+
+
+def build_retrieval_units(
+    chunk: DocumentChunk,
+    images: Mapping[str, ImageEmbeddingContent] | None = None,
+) -> list[RetrievalUnit]:
+    """Decompose one chunk into its retrieval units.
+
+    ``images`` maps resolved asset_file_id -> ImageEmbeddingContent and is only
+    used to confirm an image asset is resolvable; image bytes never enter the
+    unit (only ``asset_file_id`` is recorded).
+    """
+
+    metadata = dict(chunk.metadata or {})
+    chunk_type = metadata.get("chunk_type")
+    chunk_id = _chunk_id(chunk)
+    return_chunk_id = _return_chunk_id(chunk, chunk_id)
+
+    record = RetrievalUnit(
+        unit_id=unit_id_for(chunk_id, RetrievalUnitKind.CHUNK_RECORD, 0),
+        chunk_id=chunk_id,
+        return_chunk_id=return_chunk_id,
+        kind=RetrievalUnitKind.CHUNK_RECORD,
+        content=chunk.page_content,
+        metadata=metadata,
+    )
+    if chunk_type in {"source", "parent"}:
+        return [record]
+
+    units = [record]
+    if chunk_type == "qa":
+        text = chunk_retrieval_content(chunk)
+        if text.strip():
+            units.append(
+                RetrievalUnit(
+                    unit_id=unit_id_for(chunk_id, RetrievalUnitKind.TEXT, 0),
+                    chunk_id=chunk_id,
+                    return_chunk_id=return_chunk_id,
+                    kind=RetrievalUnitKind.TEXT,
+                    content=text,
+                    metadata=metadata,
+                )
+            )
+        return units
+
+    asset_ids = _asset_file_ids(chunk)
+    if not asset_ids:
+        text = chunk_retrieval_content(chunk)
+        if text.strip():
+            units.append(
+                RetrievalUnit(
+                    unit_id=unit_id_for(chunk_id, RetrievalUnitKind.TEXT, 0),
+                    chunk_id=chunk_id,
+                    return_chunk_id=return_chunk_id,
+                    kind=RetrievalUnitKind.TEXT,
+                    content=text,
+                    metadata=metadata,
+                )
+            )
+        return units
+
+    # Image chunk: text unit uses vision_text (the image's textual form).
+    vision_text = metadata.get("vision_text")
+    if isinstance(vision_text, str) and vision_text.strip():
+        units.append(
+            RetrievalUnit(
+                unit_id=unit_id_for(chunk_id, RetrievalUnitKind.TEXT, 0),
+                chunk_id=chunk_id,
+                return_chunk_id=return_chunk_id,
+                kind=RetrievalUnitKind.TEXT,
+                content=vision_text.strip(),
+                metadata=metadata,
+            )
+        )
+    for index, asset_id in enumerate(asset_ids):
+        if images is not None and asset_id not in images:
+            continue
+        units.append(
+            RetrievalUnit(
+                unit_id=unit_id_for(chunk_id, RetrievalUnitKind.IMAGE, index),
+                chunk_id=chunk_id,
+                return_chunk_id=return_chunk_id,
+                kind=RetrievalUnitKind.IMAGE,
+                unit_index=index,
+                asset_file_id=asset_id,
+                content="",
+                metadata=metadata,
+            )
+        )
+    return units
+
+
+__all__ = [
+    "MAX_IMAGES_PER_CHUNK",
+    "RetrievalUnit",
+    "RetrievalUnitKind",
+    "build_retrieval_units",
+    "unit_id_for",
+]

--- a/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
+++ b/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
@@ -23,7 +23,7 @@ from .elasticsearch_queries import (
     build_full_text_query,
     build_parent_lookup_query,
     build_unit_filter_clauses,
-    build_vector_knn_query,
+    build_unit_vector_script_query,
     build_vector_script_query,
     full_text_hits_to_chunks,
     merge_parent_chunks,
@@ -611,25 +611,24 @@ class AsyncElasticSearchRetrieval:
         options: RetrievalSearchOptions,
     ) -> list[UnitCandidate]:
         vector = normalize_vector(query_vector)
-        num_candidates = max(options.top_k * 4, options.knn_num_candidates or 100)
         response = await self.client.search(
             index=options.indices,
+            from_=0,
             size=options.top_k,
-            **build_vector_knn_query(
+            query=build_unit_vector_script_query(
                 vector,
                 build_unit_filter_clauses(
                     options.file_names_filter,
                     options.document_ids_include,
                 ),
-                k=options.top_k,
-                num_candidates=num_candidates,
             ),
             allow_partial_search_results=False,
         )
         self._raise_on_failed_response(response, "unit vector search")
         result: list[UnitCandidate] = []
         for hit in (response.get("hits") or {}).get("hits", []):
-            score = float(hit.get("_score") or 0)
+            # script_score emits cosine+1.0 (0..2); normalize back to 0..1.
+            score = float(hit.get("_score") or 0) / 2
             if options.score_threshold is not None and score <= options.score_threshold:
                 continue
             candidate = self._hit_to_unit_candidate(hit, score)

--- a/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
+++ b/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from dataclasses import replace
 from typing import Any, Protocol
 
 from elasticsearch.helpers import async_bulk
@@ -701,7 +702,7 @@ class AsyncElasticSearchRetrieval:
         # Image-chunk text units store vision_text as content for retrieval; the
         # chunk's real markdown body is in metadata.original_page_content.
         original = metadata.pop("original_page_content", None)
-        if isinstance(original, str) and original.strip():
+        if isinstance(original, str):
             page_content = original
         chunk = DocumentChunk(
             page_content=page_content,
@@ -747,7 +748,7 @@ class AsyncElasticSearchRetrieval:
             candidate = self._hit_to_unit_candidate(hit, score)
             if candidate is not None:
                 result.append(candidate)
-        return result
+        return await self._materialize_unit_records(result, options.indices)
 
     async def search_units_full_text(
         self,
@@ -790,6 +791,49 @@ class AsyncElasticSearchRetrieval:
             candidate = self._hit_to_unit_candidate(hit, score)
             if candidate is not None:
                 result.append(candidate)
+        return await self._materialize_unit_records(result, options.indices)
+
+    async def _materialize_unit_records(
+        self,
+        candidates: list[UnitCandidate],
+        index: str,
+    ) -> list[UnitCandidate]:
+        """Load return bodies in one batch without replacing unit retrieval inputs."""
+
+        if not candidates:
+            return []
+        chunk_ids = list(dict.fromkeys(candidate.chunk_id for candidate in candidates))
+        response = await self.client.search(
+            index=index,
+            size=len(chunk_ids),
+            query={
+                "bool": {
+                    "filter": [
+                        {"terms": {Field.CHUNK_ID.value: chunk_ids}},
+                        {"term": {Field.UNIT_KIND.value: RetrievalUnitKind.CHUNK_RECORD.value}},
+                    ]
+                }
+            },
+            source_excludes=[Field.VECTOR.value],
+            allow_partial_search_results=False,
+        )
+        self._raise_on_failed_response(response, "unit record lookup")
+        records = {
+            str((hit.get("_source") or {}).get(Field.CHUNK_ID.value)): (
+                AsyncChunkStore.hit_to_chunk(hit)
+            )
+            for hit in (response.get("hits") or {}).get("hits", [])
+        }
+        result: list[UnitCandidate] = []
+        for candidate in candidates:
+            record = records.get(candidate.chunk_id)
+            if record is None:
+                result.append(candidate)
+                continue
+            chunk = record.model_copy(deep=True)
+            chunk.metadata.pop("original_page_content", None)
+            chunk.metadata["score"] = candidate.score
+            result.append(replace(candidate, chunk=chunk))
         return result
 
     async def resolve_parent_chunks(

--- a/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
+++ b/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequenc
 from typing import Any, Protocol
 
 from elasticsearch.helpers import async_bulk
+from redbear_model import TextEmbeddingContent
 
 from ..models.chunk import DocumentChunk, chunk_retrieval_content
 from ..models.embedding import collect_asset_file_ids
@@ -57,6 +58,8 @@ class AsyncChunkStore:
         *,
         embed: EmbedFunction | None = None,
         embed_chunks: EmbedChunksFunction | None = None,
+        embed_unit_contents: Callable[[list[Any]], Awaitable[Any]] | None = None,
+        image_resolver: Any = None,
         embedding_dimension: int | None = None,
         vector_indexed: bool = True,
     ):
@@ -64,6 +67,8 @@ class AsyncChunkStore:
         self.index = collection_name_for_knowledge(knowledge_id)
         self.embed = embed
         self.embed_chunks = embed_chunks
+        self.embed_unit_contents = embed_unit_contents
+        self.image_resolver = image_resolver
         self.embedding_dimension = embedding_dimension
         self.vector_indexed = vector_indexed
 
@@ -130,6 +135,16 @@ class AsyncChunkStore:
         metadata["score"] = hit.get("_score")
         return DocumentChunk(page_content=page_content, vector=None, metadata=metadata)
 
+    def _segment_list_query(self, base: dict[str, Any]) -> dict[str, Any]:
+        """Restrict segment listing to chunk_record docs on unit indexes."""
+
+        if self.embed_unit_contents is None:
+            return base
+        bool_query = base.setdefault("bool", {})
+        filters = bool_query.setdefault("filter", [])
+        filters.append({"term": {Field.UNIT_KIND.value: "chunk_record"}})
+        return base
+
     async def search_by_segment(
         self,
         *,
@@ -144,11 +159,13 @@ class AsyncChunkStore:
         if not await self.client.indices.exists(index=self.index):
             return 0, []
         offset = pagesize * (page - 1)
-        segment_query = self.build_segment_query(
-            document_id,
-            query,
-            chunk_types,
-            parent_ids,
+        segment_query = self._segment_list_query(
+            self.build_segment_query(
+                document_id,
+                query,
+                chunk_types,
+                parent_ids,
+            )
         )
         if offset + pagesize > ES_DEFAULT_MAX_RESULT_WINDOW:
             hits = [
@@ -190,11 +207,13 @@ class AsyncChunkStore:
         async for hit in iter_async_search_after_hits(
             self.client,
             index=self.index,
-            query=self.build_segment_query(
-                document_id,
-                query,
-                chunk_types,
-                parent_ids,
+            query=self._segment_list_query(
+                self.build_segment_query(
+                    document_id,
+                    query,
+                    chunk_types,
+                    parent_ids,
+                )
             ),
             sort=self.segment_sort(asc),
             batch_size=ES_FULL_SCAN_BATCH_SIZE,
@@ -204,11 +223,22 @@ class AsyncChunkStore:
     async def get_by_segment(self, doc_id: str) -> DocumentChunk | None:
         if not await self.client.indices.exists(index=self.index):
             return None
+        if self.embed_unit_contents is not None:
+            query: dict[str, Any] = {
+                "bool": {
+                    "must": [
+                        {"term": {Field.CHUNK_ID.value: doc_id}},
+                        {"term": {Field.UNIT_KIND.value: "chunk_record"}},
+                    ]
+                }
+            }
+        else:
+            query = {"term": {Field.DOC_ID.value: doc_id}}
         response = await self.client.search(
             index=self.index,
             from_=0,
             size=1,
-            query={"term": {Field.DOC_ID.value: doc_id}},
+            query=query,
         )
         self._raise_on_failed_response(response, "segment get")
         hits = response.get("hits", {}).get("hits", [])
@@ -226,6 +256,9 @@ class AsyncChunkStore:
 
     async def add_chunks(self, chunks: list[DocumentChunk]) -> None:
         if not chunks:
+            return
+        if self.embed_unit_contents is not None:
+            await self.add_unit_chunks(chunks)
             return
         embeddings = await self._embed_chunks(chunks)
         if not await self.client.indices.exists(index=self.index):
@@ -252,6 +285,14 @@ class AsyncChunkStore:
 
     async def update_chunk(self, chunk: DocumentChunk) -> int:
         metadata = chunk.metadata or {}
+        if self.embed_unit_contents is not None:
+            # Unit layout may change with content; rebuild this chunk's units.
+            doc_id = str(metadata.get("doc_id") or "")
+            if not doc_id:
+                return 0
+            await self.delete_units_by_chunk_ids([doc_id])
+            await self.add_unit_chunks([chunk])
+            return 1
         chunk_type = metadata.get("chunk_type")
         vector = None
         if chunk_type not in {"source", "parent"}:
@@ -281,6 +322,12 @@ class AsyncChunkStore:
     async def delete_by_ids(self, ids: list[str], *, refresh: bool = False) -> int:
         if not ids or not await self.client.indices.exists(index=self.index):
             return 0
+        if self.embed_unit_contents is not None:
+            # ids are chunk doc_ids; unit docs key off chunk_id.
+            deleted = await self.delete_units_by_chunk_ids(ids)
+            if refresh:
+                await self.client.indices.refresh(index=self.index)
+            return deleted
         response = await self.client.delete_by_query(
             index=self.index,
             query={"terms": {Field.DOC_ID.value: ids}},
@@ -367,7 +414,7 @@ class AsyncChunkStore:
     async def add_unit_chunks(
         self,
         chunks: list[DocumentChunk],
-        image_resolver: Any,
+        image_resolver: Any = None,
     ) -> None:
         """Expand multimodal chunks into retrieval units and index them."""
 
@@ -375,16 +422,17 @@ class AsyncChunkStore:
             return
         if not await self.client.indices.exists(index=self.index):
             await self._create_index([])
+        resolver = image_resolver if image_resolver is not None else self.image_resolver
         asset_ids = collect_asset_file_ids(chunks)
         images = (
-            await image_resolver(asset_ids)
-            if asset_ids and image_resolver is not None
+            await resolver(asset_ids)
+            if asset_ids and resolver is not None
             else {}
         )
         actions: list[dict[str, Any]] = []
         for chunk in chunks:
             units = build_retrieval_units(chunk, images)
-            vectors = await self._embed_units(units)
+            vectors = await self._embed_units(units, images)
             if len(vectors) != len(units):
                 raise RuntimeError("Unit embedding count does not match unit count")
             for unit, vector in zip(units, vectors, strict=True):
@@ -415,22 +463,25 @@ class AsyncChunkStore:
         if actions:
             await async_bulk(self.client, actions)
 
-    async def _embed_units(self, units: list[RetrievalUnit]) -> list[list[float] | None]:
+    async def _embed_units(
+        self,
+        units: list[RetrievalUnit],
+        images: Mapping[str, Any] | None = None,
+    ) -> list[list[float] | None]:
         vectors: list[list[float] | None] = [None] * len(units)
-        text_positions = [
-            i
-            for i, u in enumerate(units)
-            if u.kind is RetrievalUnitKind.TEXT and u.content.strip()
-        ]
-        if text_positions:
-            if self.embed is None:
-                raise RuntimeError("Embedding model is required for unit embedding")
-            embedded = await self.embed([units[i].content for i in text_positions])
-            for pos, vector in zip(text_positions, embedded, strict=True):
-                vectors[pos] = vector
-        # Image-unit vectors require the multimodal embed path wired in the
-        # chunk service (P5); without it image units stay vectorless and recall
-        # falls back to the text unit (vision_text) of the same chunk.
+        embed_contents = self.embed_unit_contents
+        images = images or {}
+        for index, unit in enumerate(units):
+            contents: list[Any] = []
+            if unit.kind is RetrievalUnitKind.TEXT and unit.content.strip():
+                contents = [TextEmbeddingContent(text=unit.content)]
+            elif unit.kind is RetrievalUnitKind.IMAGE and unit.asset_file_id:
+                image = images.get(unit.asset_file_id)
+                if image is not None:
+                    contents = [image]
+            if contents and embed_contents is not None:
+                result = await embed_contents(contents)
+                vectors[index] = list(result)
         return vectors
 
     async def delete_units_by_chunk_ids(self, chunk_ids: list[str]) -> int:

--- a/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
+++ b/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from typing import Any, Protocol
@@ -366,8 +367,10 @@ class AsyncChunkStore:
 class AsyncElasticSearchRetrieval:
     """Native asynchronous vector and full-text retrieval."""
 
-    def __init__(self, client: Any):
+    def __init__(self, client: Any, *, track_parent_matches: bool = False):
         self.client = client
+        self._track_parent_matches = track_parent_matches
+        self._parent_matches: dict[tuple[str, str], set[str]] = {}
 
     @staticmethod
     def _raise_on_failed_response(response: Mapping[str, Any], operation: str) -> None:
@@ -434,6 +437,51 @@ class AsyncElasticSearchRetrieval:
             options.indices,
         )
 
+    async def score_candidates_by_vector(
+        self,
+        query_vector: Sequence[float],
+        chunks: Sequence[DocumentChunk],
+        options: RetrievalSearchOptions,
+    ) -> dict[str, float]:
+        """Score authorized candidate IDs, including only actually matched children."""
+        source_ids: dict[str, set[str]] = {}
+        for chunk in chunks:
+            metadata = chunk.metadata or {}
+            doc_id = str(metadata.get("doc_id") or "")
+            if not doc_id:
+                continue
+            source_ids[doc_id] = (
+                self._parent_matches.get((options.indices, doc_id), set())
+                if metadata.get("chunk_type") == "parent"
+                else {doc_id}
+            )
+        ids = sorted({source for sources in source_ids.values() for source in sources})
+        scores = dict.fromkeys(source_ids, 0.0)
+        if not ids or options.document_ids_include == ():
+            return scores
+        filters = build_filter_clauses(
+            options.file_names_filter, options.document_ids_include, require_vector=True
+        )
+        filters.append({"terms": {Field.DOC_ID.value: ids}})
+        response = await self.client.search(
+            index=options.indices,
+            size=len(ids),
+            query=build_vector_script_query(query_vector, filters),
+            source_includes=[Field.DOC_ID.value],
+            allow_partial_search_results=False,
+        )
+        self._raise_on_failed_response(response, "candidate vector scoring")
+        by_id: dict[str, float] = {}
+        for hit in (response.get("hits") or {}).get("hits", []):
+            doc_id = str(((hit.get("_source") or {}).get("metadata") or {}).get("doc_id") or "")
+            score = float(hit["_score"]) / 2
+            if not math.isfinite(score):
+                raise RuntimeError("Elasticsearch candidate vector score is not finite")
+            by_id[doc_id] = max(by_id.get(doc_id, 0.0), min(1.0, max(0.0, score)))
+        for doc_id, sources in source_ids.items():
+            scores[doc_id] = max((by_id.get(source, 0.0) for source in sources), default=0.0)
+        return scores
+
     async def resolve_parent_chunks(
         self,
         chunks: list[DocumentChunk],
@@ -449,6 +497,15 @@ class AsyncElasticSearchRetrieval:
         )
         if not parent_ids:
             return chunks
+        if self._track_parent_matches:
+            for chunk in chunks:
+                metadata = chunk.metadata or {}
+                if metadata.get("chunk_type") == "child" and metadata.get("parent_id"):
+                    child_id = metadata.get("doc_id")
+                    if child_id:
+                        self._parent_matches.setdefault(
+                            (index, str(metadata["parent_id"])), set()
+                        ).add(str(child_id))
         try:
             response = await self.client.search(
                 index=index,

--- a/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
+++ b/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
@@ -596,8 +596,14 @@ class AsyncElasticSearchRetrieval:
         if not kind_raw or not chunk_id:
             return None
         metadata = dict(source.get(Field.METADATA_KEY.value) or {})
+        page_content = source.get(Field.CONTENT_KEY.value) or ""
+        # Image-chunk text units store vision_text as content for retrieval; the
+        # chunk's real markdown body is in metadata.original_page_content.
+        original = metadata.pop("original_page_content", None)
+        if isinstance(original, str) and original.strip():
+            page_content = original
         chunk = DocumentChunk(
-            page_content=source.get(Field.CONTENT_KEY.value) or "",
+            page_content=page_content,
             metadata=metadata,
         )
         return UnitCandidate(

--- a/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
+++ b/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
@@ -412,6 +412,18 @@ class AsyncChunkStore:
                     "answer": {"type": "text", "analyzer": "ik_max_word"},
                     "source_chunk_id": {"type": "keyword"},
                     "parent_id": {"type": "keyword"},
+                    **(
+                        {
+                            Field.UNIT_ID.value: {"type": "keyword"},
+                            Field.UNIT_KIND.value: {"type": "keyword"},
+                            Field.UNIT_INDEX.value: {"type": "long"},
+                            Field.CHUNK_ID.value: {"type": "keyword"},
+                            Field.RETURN_CHUNK_ID.value: {"type": "keyword"},
+                            Field.ASSET_FILE_ID.value: {"type": "keyword"},
+                        }
+                        if self.multimodal
+                        else {}
+                    ),
                 }
             },
             settings={"index": {"refresh_interval": "1s"}},

--- a/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
+++ b/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
@@ -9,12 +9,20 @@ from typing import Any, Protocol
 from elasticsearch.helpers import async_bulk
 
 from ..models.chunk import DocumentChunk, chunk_retrieval_content
+from ..models.embedding import collect_asset_file_ids
+from ..models.retrieval_unit import (
+    RetrievalUnit,
+    RetrievalUnitKind,
+    build_retrieval_units,
+)
 from ..vdb.field import Field
 from ..vdb.pit_search import iter_async_search_after_hits
 from .elasticsearch_queries import (
     build_filter_clauses,
     build_full_text_query,
     build_parent_lookup_query,
+    build_unit_filter_clauses,
+    build_vector_knn_query,
     build_vector_script_query,
     full_text_hits_to_chunks,
     merge_parent_chunks,
@@ -22,6 +30,7 @@ from .elasticsearch_queries import (
     vector_hits_to_chunks,
 )
 from .models import RetrievalSearchOptions
+from .unit_collapse import UnitCandidate
 
 ES_DEFAULT_MAX_RESULT_WINDOW = 10000
 ES_FULL_SCAN_BATCH_SIZE = 1000
@@ -355,6 +364,89 @@ class AsyncChunkStore:
             settings={"index": {"refresh_interval": "1s"}},
         )
 
+    async def add_unit_chunks(
+        self,
+        chunks: list[DocumentChunk],
+        image_resolver: Any,
+    ) -> None:
+        """Expand multimodal chunks into retrieval units and index them."""
+
+        if not chunks:
+            return
+        if not await self.client.indices.exists(index=self.index):
+            await self._create_index([])
+        asset_ids = collect_asset_file_ids(chunks)
+        images = (
+            await image_resolver(asset_ids)
+            if asset_ids and image_resolver is not None
+            else {}
+        )
+        actions: list[dict[str, Any]] = []
+        for chunk in chunks:
+            units = build_retrieval_units(chunk, images)
+            vectors = await self._embed_units(units)
+            if len(vectors) != len(units):
+                raise RuntimeError("Unit embedding count does not match unit count")
+            for unit, vector in zip(units, vectors, strict=True):
+                source: dict[str, Any] = {
+                    Field.UNIT_ID.value: unit.unit_id,
+                    Field.UNIT_KIND.value: unit.kind.value,
+                    Field.UNIT_INDEX.value: unit.unit_index,
+                    Field.CHUNK_ID.value: unit.chunk_id,
+                    Field.RETURN_CHUNK_ID.value: unit.return_chunk_id,
+                    Field.CONTENT_KEY.value: unit.content,
+                    Field.METADATA_KEY.value: unit.metadata,
+                    Field.VECTOR.value: vector,
+                }
+                if unit.asset_file_id is not None:
+                    source[Field.ASSET_FILE_ID.value] = unit.asset_file_id
+                for field, key in (
+                    (Field.CHUNK_TYPE, "chunk_type"),
+                    (Field.QUESTION, "question"),
+                    (Field.ANSWER, "answer"),
+                    (Field.SOURCE_CHUNK_ID, "source_chunk_id"),
+                    (Field.PARENT_ID, "parent_id"),
+                ):
+                    if unit.metadata.get(key):
+                        source[field.value] = unit.metadata[key]
+                actions.append(
+                    {"_id": unit.unit_id, "_index": self.index, "_source": source}
+                )
+        if actions:
+            await async_bulk(self.client, actions)
+
+    async def _embed_units(self, units: list[RetrievalUnit]) -> list[list[float] | None]:
+        vectors: list[list[float] | None] = [None] * len(units)
+        text_positions = [
+            i
+            for i, u in enumerate(units)
+            if u.kind is RetrievalUnitKind.TEXT and u.content.strip()
+        ]
+        if text_positions:
+            if self.embed is None:
+                raise RuntimeError("Embedding model is required for unit embedding")
+            embedded = await self.embed([units[i].content for i in text_positions])
+            for pos, vector in zip(text_positions, embedded, strict=True):
+                vectors[pos] = vector
+        # Image-unit vectors require the multimodal embed path wired in the
+        # chunk service (P5); without it image units stay vectorless and recall
+        # falls back to the text unit (vision_text) of the same chunk.
+        return vectors
+
+    async def delete_units_by_chunk_ids(self, chunk_ids: list[str]) -> int:
+        """Cascade-delete every unit (and chunk_record) of the given chunks."""
+
+        if not chunk_ids or not await self.client.indices.exists(index=self.index):
+            return 0
+        response = await self.client.delete_by_query(
+            index=self.index,
+            query={"terms": {Field.CHUNK_ID.value: chunk_ids}},
+            conflicts="abort",
+            wait_for_completion=True,
+        )
+        self._raise_on_failed_response(response, "unit delete")
+        return int(response.get("deleted", 0))
+
     @staticmethod
     def _raise_on_failed_response(response: Mapping[str, Any], operation: str) -> None:
         if response.get("timed_out") or response.get("failures"):
@@ -433,6 +525,109 @@ class AsyncElasticSearchRetrieval:
             full_text_hits_to_chunks(response, options.score_threshold),
             options.indices,
         )
+
+    # --- Multimodal unit-granularity recall (qwen3-vl indexes) ---
+
+    def _hit_to_unit_candidate(
+        self,
+        hit: Mapping[str, Any],
+        score: float,
+    ) -> UnitCandidate | None:
+        source = hit.get("_source") or {}
+        kind_raw = source.get(Field.UNIT_KIND.value)
+        chunk_id = source.get(Field.CHUNK_ID.value)
+        if not kind_raw or not chunk_id:
+            return None
+        metadata = dict(source.get(Field.METADATA_KEY.value) or {})
+        chunk = DocumentChunk(
+            page_content=source.get(Field.CONTENT_KEY.value) or "",
+            metadata=metadata,
+        )
+        return UnitCandidate(
+            unit_id=str(source.get(Field.UNIT_ID.value) or ""),
+            chunk_id=str(chunk_id),
+            return_chunk_id=str(source.get(Field.RETURN_CHUNK_ID.value) or chunk_id),
+            kind=RetrievalUnitKind(kind_raw),
+            asset_file_id=source.get(Field.ASSET_FILE_ID.value),
+            content=source.get(Field.CONTENT_KEY.value) or "",
+            score=score,
+            chunk=chunk,
+        )
+
+    async def search_units_by_vector(
+        self,
+        query_vector: Sequence[float],
+        options: RetrievalSearchOptions,
+    ) -> list[UnitCandidate]:
+        vector = normalize_vector(query_vector)
+        num_candidates = max(options.top_k * 4, options.knn_num_candidates or 100)
+        response = await self.client.search(
+            index=options.indices,
+            size=options.top_k,
+            **build_vector_knn_query(
+                vector,
+                build_unit_filter_clauses(
+                    options.file_names_filter,
+                    options.document_ids_include,
+                ),
+                k=options.top_k,
+                num_candidates=num_candidates,
+            ),
+            allow_partial_search_results=False,
+        )
+        self._raise_on_failed_response(response, "unit vector search")
+        result: list[UnitCandidate] = []
+        for hit in (response.get("hits") or {}).get("hits", []):
+            score = float(hit.get("_score") or 0)
+            if options.score_threshold is not None and score <= options.score_threshold:
+                continue
+            candidate = self._hit_to_unit_candidate(hit, score)
+            if candidate is not None:
+                result.append(candidate)
+        return result
+
+    async def search_units_full_text(
+        self,
+        query: str,
+        options: RetrievalSearchOptions,
+    ) -> list[UnitCandidate]:
+        """Full-text recall restricted to text units (Q9)."""
+
+        filters = build_unit_filter_clauses(
+            options.file_names_filter,
+            options.document_ids_include,
+            unit_kinds=[RetrievalUnitKind.TEXT.value],
+        )
+        response = await self.client.search(
+            index=options.indices,
+            from_=0,
+            size=options.top_k,
+            query={
+                "bool": {
+                    "must": {
+                        "multi_match": {
+                            "query": query,
+                            "fields": [Field.CONTENT_KEY.value, Field.VISION_TEXT.value],
+                            "analyzer": "ik_max_word",
+                        }
+                    },
+                    "filter": filters,
+                }
+            },
+            allow_partial_search_results=False,
+        )
+        self._raise_on_failed_response(response, "unit full text search")
+        hits = (response.get("hits") or {})
+        max_score = float(hits.get("max_score") or 1)
+        result: list[UnitCandidate] = []
+        for hit in hits.get("hits", []):
+            score = float(hit.get("_score") or 0) / max_score
+            if options.score_threshold is not None and score <= options.score_threshold:
+                continue
+            candidate = self._hit_to_unit_candidate(hit, score)
+            if candidate is not None:
+                result.append(candidate)
+        return result
 
     async def resolve_parent_chunks(
         self,

--- a/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
+++ b/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from typing import Any, Protocol
@@ -292,13 +293,7 @@ class AsyncChunkStore:
     async def update_chunk(self, chunk: DocumentChunk) -> int:
         metadata = chunk.metadata or {}
         if self.multimodal:
-            # Unit layout may change with content; rebuild this chunk's units.
-            doc_id = str(metadata.get("doc_id") or "")
-            if not doc_id:
-                return 0
-            await self.delete_units_by_chunk_ids([doc_id])
-            await self.add_unit_chunks([chunk])
-            return 1
+            return await self._update_unit_chunk(chunk)
         chunk_type = metadata.get("chunk_type")
         vector = None
         if chunk_type not in {"source", "parent"}:
@@ -324,6 +319,92 @@ class AsyncChunkStore:
         )
         self._raise_on_failed_response(response, "segment update")
         return int(response.get("updated", 0))
+
+    async def _update_unit_chunk(self, chunk: DocumentChunk) -> int:
+        """Prepare content edits without reloading images or deleting existing units."""
+
+        doc_id = str((chunk.metadata or {}).get("doc_id") or "")
+        if not doc_id or not await self.client.indices.exists(index=self.index):
+            return 0
+        existing = {
+            hit["_id"]: hit.get("_source") or {}
+            async for hit in iter_async_search_after_hits(
+                self.client,
+                index=self.index,
+                query={"term": {Field.CHUNK_ID.value: doc_id}},
+                sort=[{Field.UNIT_ID.value: "asc"}],
+                batch_size=ES_FULL_SCAN_BATCH_SIZE,
+            )
+        }
+        record = next(
+            (
+                source for source in existing.values()
+                if source.get(Field.UNIT_KIND.value) == RetrievalUnitKind.CHUNK_RECORD.value
+            ),
+            None,
+        )
+        if record is None:
+            return 0
+        # The edit API changes only the body or QA fields. Keep immutable image
+        # inputs and vision_text from the authoritative stored record.
+        metadata = dict(record.get(Field.METADATA_KEY.value) or {})
+        if (chunk.metadata or {}).get("chunk_type") == "qa":
+            metadata.update(
+                chunk_type="qa",
+                question=chunk.metadata.get("question", ""),
+                answer=chunk.metadata.get("answer", ""),
+            )
+        edited = DocumentChunk(page_content=chunk.page_content, metadata=metadata)
+        actions: list[dict[str, Any]] = []
+        retained_ids: set[str] = set()
+        for unit in build_retrieval_units(edited):
+            old = existing.get(unit.unit_id)
+            vector = None
+            if unit.kind is RetrievalUnitKind.IMAGE:
+                # Editing content does not repair missing image units or replace assets.
+                if old is None:
+                    continue
+                vector = old.get(Field.VECTOR.value)
+            elif unit.kind is RetrievalUnitKind.TEXT:
+                if old is not None and old.get(Field.CONTENT_KEY.value) == unit.content:
+                    vector = old.get(Field.VECTOR.value)
+                else:
+                    if self.embed_unit_contents is None:
+                        raise RuntimeError("Embedding model is required for changed unit text")
+                    vector = list(await self.embed_unit_contents(
+                        [TextEmbeddingContent(text=unit.content)]
+                    ))
+                    if (
+                        not vector
+                        or (self.embedding_dimension and len(vector) != self.embedding_dimension)
+                        or not all(math.isfinite(value) for value in vector)
+                    ):
+                        raise RuntimeError("Embedding result has an invalid vector")
+            if unit.kind is not RetrievalUnitKind.CHUNK_RECORD:
+                unit.metadata["original_page_content"] = edited.page_content
+            actions.append(
+                {
+                    "_id": unit.unit_id,
+                    "_index": self.index,
+                    "_source": self._unit_source(unit, vector),
+                }
+            )
+            retained_ids.add(unit.unit_id)
+
+        # All external preparation has succeeded. Stable IDs replace documents
+        # in place; failed writes never trigger removal of the previous unit set.
+        await async_bulk(self.client, actions, refresh="wait_for")
+        stale_ids = existing.keys() - retained_ids
+        if stale_ids:
+            await async_bulk(
+                self.client,
+                [
+                    {"_op_type": "delete", "_index": self.index, "_id": unit_id}
+                    for unit_id in stale_ids
+                ],
+                refresh="wait_for",
+            )
+        return 1
 
     async def delete_by_ids(self, ids: list[str], *, refresh: bool = False) -> int:
         if not ids or not await self.client.indices.exists(index=self.index):
@@ -454,32 +535,40 @@ class AsyncChunkStore:
             if len(vectors) != len(units):
                 raise RuntimeError("Unit embedding count does not match unit count")
             for unit, vector in zip(units, vectors, strict=True):
-                source: dict[str, Any] = {
-                    Field.UNIT_ID.value: unit.unit_id,
-                    Field.UNIT_KIND.value: unit.kind.value,
-                    Field.UNIT_INDEX.value: unit.unit_index,
-                    Field.CHUNK_ID.value: unit.chunk_id,
-                    Field.RETURN_CHUNK_ID.value: unit.return_chunk_id,
-                    Field.CONTENT_KEY.value: unit.content,
-                    Field.METADATA_KEY.value: unit.metadata,
-                    Field.VECTOR.value: vector,
-                }
-                if unit.asset_file_id is not None:
-                    source[Field.ASSET_FILE_ID.value] = unit.asset_file_id
-                for field, key in (
-                    (Field.CHUNK_TYPE, "chunk_type"),
-                    (Field.QUESTION, "question"),
-                    (Field.ANSWER, "answer"),
-                    (Field.SOURCE_CHUNK_ID, "source_chunk_id"),
-                    (Field.PARENT_ID, "parent_id"),
-                ):
-                    if unit.metadata.get(key):
-                        source[field.value] = unit.metadata[key]
                 actions.append(
-                    {"_id": unit.unit_id, "_index": self.index, "_source": source}
+                    {
+                        "_id": unit.unit_id,
+                        "_index": self.index,
+                        "_source": self._unit_source(unit, vector),
+                    }
                 )
         if actions:
             await async_bulk(self.client, actions)
+
+    @staticmethod
+    def _unit_source(unit: RetrievalUnit, vector: list[float] | None) -> dict[str, Any]:
+        source: dict[str, Any] = {
+            Field.UNIT_ID.value: unit.unit_id,
+            Field.UNIT_KIND.value: unit.kind.value,
+            Field.UNIT_INDEX.value: unit.unit_index,
+            Field.CHUNK_ID.value: unit.chunk_id,
+            Field.RETURN_CHUNK_ID.value: unit.return_chunk_id,
+            Field.CONTENT_KEY.value: unit.content,
+            Field.METADATA_KEY.value: unit.metadata,
+            Field.VECTOR.value: vector,
+        }
+        if unit.asset_file_id is not None:
+            source[Field.ASSET_FILE_ID.value] = unit.asset_file_id
+        for field in (
+            Field.CHUNK_TYPE,
+            Field.QUESTION,
+            Field.ANSWER,
+            Field.SOURCE_CHUNK_ID,
+            Field.PARENT_ID,
+        ):
+            if unit.metadata.get(field.value):
+                source[field.value] = unit.metadata[field.value]
+        return source
 
     async def _embed_units(
         self,

--- a/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
+++ b/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
@@ -62,6 +62,7 @@ class AsyncChunkStore:
         image_resolver: Any = None,
         embedding_dimension: int | None = None,
         vector_indexed: bool = True,
+        multimodal: bool | None = None,
     ):
         self.client = client
         self.index = collection_name_for_knowledge(knowledge_id)
@@ -71,6 +72,11 @@ class AsyncChunkStore:
         self.image_resolver = image_resolver
         self.embedding_dimension = embedding_dimension
         self.vector_indexed = vector_indexed
+        # Unit-layout index marker. Read-only callers (chunk list) set this
+        # without wiring embedders so they still collapse/filter units correctly.
+        self.multimodal = (
+            multimodal if multimodal is not None else embed_unit_contents is not None
+        )
 
     @staticmethod
     def build_segment_query(
@@ -138,7 +144,7 @@ class AsyncChunkStore:
     def _segment_list_query(self, base: dict[str, Any]) -> dict[str, Any]:
         """Restrict segment listing to chunk_record docs on unit indexes."""
 
-        if self.embed_unit_contents is None:
+        if not self.multimodal:
             return base
         bool_query = base.setdefault("bool", {})
         filters = bool_query.setdefault("filter", [])
@@ -223,7 +229,7 @@ class AsyncChunkStore:
     async def get_by_segment(self, doc_id: str) -> DocumentChunk | None:
         if not await self.client.indices.exists(index=self.index):
             return None
-        if self.embed_unit_contents is not None:
+        if self.multimodal:
             query: dict[str, Any] = {
                 "bool": {
                     "must": [
@@ -257,7 +263,7 @@ class AsyncChunkStore:
     async def add_chunks(self, chunks: list[DocumentChunk]) -> None:
         if not chunks:
             return
-        if self.embed_unit_contents is not None:
+        if self.multimodal:
             await self.add_unit_chunks(chunks)
             return
         embeddings = await self._embed_chunks(chunks)
@@ -285,7 +291,7 @@ class AsyncChunkStore:
 
     async def update_chunk(self, chunk: DocumentChunk) -> int:
         metadata = chunk.metadata or {}
-        if self.embed_unit_contents is not None:
+        if self.multimodal:
             # Unit layout may change with content; rebuild this chunk's units.
             doc_id = str(metadata.get("doc_id") or "")
             if not doc_id:
@@ -322,7 +328,7 @@ class AsyncChunkStore:
     async def delete_by_ids(self, ids: list[str], *, refresh: bool = False) -> int:
         if not ids or not await self.client.indices.exists(index=self.index):
             return 0
-        if self.embed_unit_contents is not None:
+        if self.multimodal:
             # ids are chunk doc_ids; unit docs key off chunk_id.
             deleted = await self.delete_units_by_chunk_ids(ids)
             if refresh:

--- a/mem-knowledge/src/rag/retrieval/candidates.py
+++ b/mem-knowledge/src/rag/retrieval/candidates.py
@@ -52,7 +52,92 @@ def chunk_identity(chunk: DocumentChunk) -> tuple[Any, ...]:
 
 
 def candidate_identity(candidate: RetrievalCandidate) -> tuple[Any, ...]:
-    return chunk_identity(candidate.chunk)
+    return retrieval_identity(candidate.chunk, candidate.knowledge_id)
+
+
+def retrieval_identity(
+    chunk: DocumentChunk, knowledge_id: uuid.UUID | None = None,
+) -> tuple[Any, ...]:
+    """Keep unit identity until ranking; legacy candidates retain chunk identity."""
+
+    metadata = chunk.metadata or {}
+    if metadata.get("_unit_id"):
+        return (
+            "unit_id",
+            str(knowledge_id or metadata.get("knowledge_id") or ""),
+            metadata["_unit_id"],
+        )
+    return chunk_identity(chunk)
+
+
+def has_unit_candidates(candidates: Sequence[RetrievalCandidate]) -> bool:
+    return any((candidate.chunk.metadata or {}).get("_unit_id") for candidate in candidates)
+
+
+def _chunk_key(candidate: RetrievalCandidate) -> tuple[Any, ...]:
+    return (candidate.knowledge_id, *chunk_identity(candidate.chunk))
+
+
+def _return_chunk_key(candidate: RetrievalCandidate) -> tuple[Any, ...]:
+    metadata = candidate.chunk.metadata or {}
+    return_id = metadata.get("_return_chunk_id")
+    if metadata.get("_unit_id") and return_id:
+        return (candidate.knowledge_id, "doc_id", str(return_id))
+    return _chunk_key(candidate)
+
+
+def _rank_score(candidate: RetrievalCandidate) -> float:
+    return candidate.final_score if candidate.final_score is not None else _score(candidate.chunk)
+
+
+def collapse_ranked_candidates(
+    candidates: Sequence[RetrievalCandidate],
+) -> list[RetrievalCandidate]:
+    """Choose the highest-scoring unit of each return chunk after ranking."""
+
+    best: dict[tuple[Any, ...], RetrievalCandidate] = {}
+    for candidate in candidates:
+        key = _return_chunk_key(candidate)
+        if key not in best or _rank_score(candidate) > _rank_score(best[key]):
+            best[key] = candidate
+    return sorted(best.values(), key=_rank_score, reverse=True)
+
+
+def select_top_chunk_units(
+    candidates: Sequence[RetrievalCandidate], top_k: int,
+) -> list[RetrievalCandidate]:
+    """Limit distinct chunks while keeping their units for subsequent model stages."""
+
+    selected = {
+        _return_chunk_key(candidate) for candidate in collapse_ranked_candidates(candidates)[:top_k]
+    }
+    return [candidate for candidate in candidates if _return_chunk_key(candidate) in selected]
+
+
+def aggregate_chunk_channel_scores(
+    candidates: Sequence[RetrievalCandidate],
+) -> list[RetrievalCandidate]:
+    """Preserve pre-unitization weighted scoring without discarding unit identities."""
+
+    totals: dict[tuple[Any, ...], RetrievalCandidate] = {}
+    for candidate in candidates:
+        key = _chunk_key(candidate)
+        previous = totals.get(key, candidate)
+        totals[key] = replace(
+            previous,
+            semantic_score=_maximum(previous.semantic_score, candidate.semantic_score),
+            participle_score=_maximum(previous.participle_score, candidate.participle_score),
+            graph_score=_maximum(previous.graph_score, candidate.graph_score),
+        )
+    return [
+        replace(
+            candidate,
+            semantic_score=totals[_chunk_key(candidate)].semantic_score,
+            participle_score=totals[_chunk_key(candidate)].participle_score,
+            graph_score=totals[_chunk_key(candidate)].graph_score,
+        )
+        for candidate in candidates
+    ]
 
 
 def _maximum(left: float | None, right: float | None) -> float | None:
@@ -104,16 +189,23 @@ def materialize_candidates(
         if score is None:
             score = _score(candidate.chunk)
         chunk.metadata["score"] = score
+        if chunk.metadata.get("_unit_id"):
+            chunk.metadata["knowledge_id"] = str(candidate.knowledge_id)
         result.append(chunk)
     return result
 
 
 __all__ = [
+    "aggregate_chunk_channel_scores",
     "RetrievalChannel",
     "candidate_identity",
     "candidate_from_chunk",
     "chunk_identity",
+    "collapse_ranked_candidates",
     "deduplicate_candidates_first_win",
     "materialize_candidates",
     "merge_candidates",
+    "has_unit_candidates",
+    "retrieval_identity",
+    "select_top_chunk_units",
 ]

--- a/mem-knowledge/src/rag/retrieval/elasticsearch_queries.py
+++ b/mem-knowledge/src/rag/retrieval/elasticsearch_queries.py
@@ -122,6 +122,20 @@ def build_vector_knn_query(
     }
 
 
+def build_unit_vector_script_query(
+    query_vector: Sequence[float],
+    filters: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    """Scripted cosine recall over unit vectors (2048-dim, non-indexed).
+
+    The unit index stores 2048-dim qwen3-vl vectors which this ES version cannot
+    index for HNSW, so vector recall uses the same script_score cosine as the
+    legacy fused path, scoped to units via ``filters``.
+    """
+
+    return build_vector_script_query(query_vector, filters)
+
+
 def raise_on_shard_failures(result: Mapping[str, Any], context: str) -> None:
     failed = int((result.get("_shards") or {}).get("failed") or 0)
     if failed:

--- a/mem-knowledge/src/rag/retrieval/elasticsearch_queries.py
+++ b/mem-knowledge/src/rag/retrieval/elasticsearch_queries.py
@@ -76,6 +76,52 @@ def build_vector_script_query(
     }
 
 
+def build_unit_filter_clauses(
+    file_names_filter: Sequence[str] | None,
+    document_ids_include: Sequence[str] | None,
+    *,
+    unit_kinds: Sequence[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Filter clauses for unit-granularity recall on a multimodal index.
+
+    Always excludes ``chunk_record`` docs (authoritative records, no vector) and
+    optionally restricts to specific unit kinds (e.g. text-only for full text).
+    """
+
+    filters = build_filter_clauses(
+        file_names_filter,
+        document_ids_include,
+        require_vector=True,
+    )
+    if unit_kinds:
+        filters.append({"terms": {Field.UNIT_KIND.value: list(unit_kinds)}})
+    else:
+        filters.append(
+            {"bool": {"must_not": [{"term": {Field.UNIT_KIND.value: "chunk_record"}}]}}
+        )
+    return filters
+
+
+def build_vector_knn_query(
+    query_vector: Sequence[float],
+    filters: Sequence[dict[str, Any]],
+    *,
+    k: int,
+    num_candidates: int,
+) -> dict[str, Any]:
+    """Approximate HNSW kNN query for the multimodal unit index."""
+
+    return {
+        "knn": {
+            "field": Field.VECTOR.value,
+            "query_vector": list(query_vector),
+            "k": k,
+            "num_candidates": num_candidates,
+            "filter": list(filters),
+        }
+    }
+
+
 def raise_on_shard_failures(result: Mapping[str, Any], context: str) -> None:
     failed = int((result.get("_shards") or {}).get("failed") or 0)
     if failed:
@@ -95,6 +141,18 @@ def _hit_to_chunk(
         answer = source.get(Field.ANSWER.value, "")
         page_content = f"question: {question}\nanswer: {answer}"
         metadata.update(chunk_type="qa", question=question, answer=answer)
+    # Carry unit identity through metadata so the service layer can fold units
+    # back to chunks. Underscore-prefixed keys are internal and never emitted.
+    for src_key, meta_key in (
+        (Field.UNIT_ID.value, "_unit_id"),
+        (Field.UNIT_KIND.value, "_unit_kind"),
+        (Field.CHUNK_ID.value, "_chunk_id"),
+        (Field.RETURN_CHUNK_ID.value, "_return_chunk_id"),
+        (Field.ASSET_FILE_ID.value, "_asset_file_id"),
+    ):
+        value = source.get(src_key)
+        if value is not None:
+            metadata[meta_key] = value
     metadata["score"] = score
     return DocumentChunk(page_content=page_content, metadata=metadata)
 
@@ -167,6 +225,8 @@ __all__ = [
     "build_filter_clauses",
     "build_full_text_query",
     "build_parent_lookup_query",
+    "build_unit_filter_clauses",
+    "build_vector_knn_query",
     "build_vector_script_query",
     "full_text_hits_to_chunks",
     "merge_parent_chunks",

--- a/mem-knowledge/src/rag/retrieval/elasticsearch_queries.py
+++ b/mem-knowledge/src/rag/retrieval/elasticsearch_queries.py
@@ -15,6 +15,20 @@ def normalize_vector(vector: Any) -> list[float]:
     return list(vector)
 
 
+def build_chunk_record_filter() -> dict[str, Any]:
+    """Select authoritative unit records and documents from legacy chunk indexes."""
+
+    return {
+        "bool": {
+            "should": [
+                {"term": {Field.UNIT_KIND.value: "chunk_record"}},
+                {"bool": {"must_not": [{"exists": {"field": Field.UNIT_KIND.value}}]}},
+            ],
+            "minimum_should_match": 1,
+        }
+    }
+
+
 def build_filter_clauses(
     file_names_filter: Sequence[str] | None,
     document_ids_include: Sequence[str] | None,
@@ -236,6 +250,7 @@ def merge_parent_chunks(
 
 
 __all__ = [
+    "build_chunk_record_filter",
     "build_filter_clauses",
     "build_full_text_query",
     "build_parent_lookup_query",

--- a/mem-knowledge/src/rag/retrieval/models.py
+++ b/mem-knowledge/src/rag/retrieval/models.py
@@ -36,6 +36,7 @@ class RerankPlan:
     weights: RerankWeightsSnapshot
     model: ModelRuntimeSnapshot | None
     compatibility_fallback: bool
+    recompute_keywords: bool = False
 
 
 @dataclass(frozen=True)

--- a/mem-knowledge/src/rag/retrieval/rerank.py
+++ b/mem-knowledge/src/rag/retrieval/rerank.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 
 from redbear_model import ImageEmbeddingContent
 
 from ...api.schemas.rerank import RerankMode
-from ..models.chunk import DocumentChunk
+from ..models.chunk import DocumentChunk, chunk_retrieval_content
 from .candidates import candidate_identity, chunk_identity, materialize_candidates
 from .models import ModelRuntimeSnapshot, RerankPlan, RetrievalCandidate
+from .weighted_scoring import keyword_similarities
 
 
 @dataclass(frozen=True)
@@ -40,13 +42,21 @@ class _WeightedScoreAdapter:
         candidates: Sequence[RetrievalCandidate],
         plan: RerankPlan,
     ) -> list[RetrievalCandidate]:
-        del query
+        keyword_scores = [candidate.participle_score or 0.0 for candidate in candidates]
+        if plan.recompute_keywords and plan.weights.participle_weight > 0:
+            if not isinstance(query, str):
+                raise ValueError("Weighted keyword scoring requires a text query")
+            keyword_scores = await asyncio.to_thread(
+                keyword_similarities,
+                query,
+                [chunk_retrieval_content(candidate.chunk) for candidate in candidates],
+            )
         ranked = [
             candidate.with_final_score(
                 plan.weights.semantic_weight * (candidate.semantic_score or 0.0)
-                + plan.weights.participle_weight * (candidate.participle_score or 0.0)
+                + plan.weights.participle_weight * keyword_score
             )
-            for candidate in candidates
+            for candidate, keyword_score in zip(candidates, keyword_scores, strict=True)
         ]
         return sorted(
             ranked,

--- a/mem-knowledge/src/rag/retrieval/rerank.py
+++ b/mem-knowledge/src/rag/retrieval/rerank.py
@@ -9,7 +9,14 @@ from redbear_model import ImageEmbeddingContent
 
 from ...api.schemas.rerank import RerankMode
 from ..models.chunk import DocumentChunk
-from .candidates import candidate_identity, chunk_identity, materialize_candidates
+from .candidates import (
+    aggregate_chunk_channel_scores,
+    candidate_identity,
+    has_unit_candidates,
+    materialize_candidates,
+    retrieval_identity,
+    select_top_chunk_units,
+)
 from .models import ModelRuntimeSnapshot, RerankPlan, RetrievalCandidate
 
 
@@ -41,6 +48,8 @@ class _WeightedScoreAdapter:
         plan: RerankPlan,
     ) -> list[RetrievalCandidate]:
         del query
+        if has_unit_candidates(candidates):
+            candidates = aggregate_chunk_channel_scores(candidates)
         ranked = [
             candidate.with_final_score(
                 plan.weights.semantic_weight * (candidate.semantic_score or 0.0)
@@ -84,7 +93,7 @@ class _ModelRerankAdapter:
         }
         result: list[RetrievalCandidate] = []
         for chunk in model_result.chunks:
-            identity = chunk_identity(chunk)
+            identity = retrieval_identity(chunk)
             candidate = candidates_by_identity.get(identity)
             if candidate is None:
                 continue
@@ -116,6 +125,7 @@ class RerankEngine:
         top_k: int,
         score_threshold: float,
     ) -> list[RetrievalCandidate]:
+        unit_ranking = has_unit_candidates(candidates)
         if plan.mode is RerankMode.WEIGHTED_SCORE:
             ranked = await self._weighted.rank(
                 query=query,
@@ -127,7 +137,7 @@ class RerankEngine:
                 query=query,
                 candidates=candidates,
                 plan=plan,
-                top_k=top_k,
+                top_k=len(candidates) if unit_ranking else top_k,
             )
         filtered = [
             candidate
@@ -135,6 +145,8 @@ class RerankEngine:
             if candidate.final_score is not None
             and candidate.final_score > score_threshold
         ]
+        if unit_ranking:
+            return select_top_chunk_units(filtered, top_k)
         return filtered[:top_k]
 
 

--- a/mem-knowledge/src/rag/retrieval/unit_collapse.py
+++ b/mem-knowledge/src/rag/retrieval/unit_collapse.py
@@ -58,6 +58,11 @@ def collapse_units_to_chunks(
         chunk = candidate.chunk.model_copy(deep=True)
         metadata = dict(chunk.metadata or {})
         metadata["score"] = score
+        # Mark child hits so downstream parent resolution swaps in the parent.
+        # A unit whose return target differs from its own chunk is a child.
+        if candidate.return_chunk_id and candidate.return_chunk_id != candidate.chunk_id:
+            metadata.setdefault("chunk_type", "child")
+            metadata["parent_id"] = candidate.return_chunk_id
         chunk.metadata = metadata
         result.append(chunk)
     return result

--- a/mem-knowledge/src/rag/retrieval/unit_collapse.py
+++ b/mem-knowledge/src/rag/retrieval/unit_collapse.py
@@ -1,0 +1,96 @@
+"""Collapse unit-level retrieval candidates back to chunk candidates.
+
+Multimodal recall and rerank operate on retrieval units; this module folds
+unit scores back to their source chunk (chunk score = max of its unit scores)
+and trims an over-limit unit candidate list for rerank (drop lowest-scoring
+units, logging a warning) without ever failing the request.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from ..models.chunk import DocumentChunk
+from ..models.retrieval_unit import RetrievalUnitKind
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class UnitCandidate:
+    """A recalled/reranked unit bound to its materialized chunk snapshot."""
+
+    unit_id: str
+    chunk_id: str
+    return_chunk_id: str
+    kind: RetrievalUnitKind
+    asset_file_id: str | None
+    content: str
+    score: float
+    chunk: DocumentChunk
+
+
+def _finite(score: float) -> float:
+    return score if math.isfinite(score) else 0.0
+
+
+def collapse_units_to_chunks(
+    candidates: Sequence[UnitCandidate],
+) -> list[DocumentChunk]:
+    """Fold unit candidates into chunk candidates ordered by max unit score."""
+
+    best_by_chunk: dict[str, tuple[float, UnitCandidate, int]] = {}
+    for order, candidate in enumerate(candidates):
+        score = _finite(candidate.score)
+        key = candidate.return_chunk_id
+        existing = best_by_chunk.get(key)
+        if existing is None or score > existing[0]:
+            best_by_chunk[key] = (score, candidate, order)
+    ranked = sorted(
+        best_by_chunk.values(),
+        key=lambda item: (-item[0], item[2]),
+    )
+    result: list[DocumentChunk] = []
+    for score, candidate, _ in ranked:
+        chunk = candidate.chunk.model_copy(deep=True)
+        metadata = dict(chunk.metadata or {})
+        metadata["score"] = score
+        chunk.metadata = metadata
+        result.append(chunk)
+    return result
+
+
+def select_units_for_rerank(
+    candidates: Sequence[UnitCandidate],
+    *,
+    max_text: int,
+    max_image: int,
+) -> list[UnitCandidate]:
+    """Trim an over-limit unit list by dropping lowest-scoring units.
+
+    Text units keep the top ``max_text`` by score; image units keep the top
+    ``max_image`` by score. A warning is logged whenever anything is dropped.
+    """
+
+    text = [c for c in candidates if c.kind is RetrievalUnitKind.TEXT]
+    image = [c for c in candidates if c.kind is RetrievalUnitKind.IMAGE]
+    if len(text) <= max_text and len(image) <= max_image:
+        return list(candidates)
+    kept_text = sorted(text, key=lambda c: -_finite(c.score))[:max_text]
+    kept_image = sorted(image, key=lambda c: -_finite(c.score))[:max_image]
+    logger.warning(
+        "event=kb_multimodal_rerank_units_trimmed "
+        "text_before=%s text_after=%s image_before=%s image_after=%s",
+        len(text),
+        len(kept_text),
+        len(image),
+        len(kept_image),
+    )
+    kept_ids = {c.unit_id for c in (*kept_text, *kept_image)}
+    return [c for c in candidates if c.unit_id in kept_ids]
+
+
+__all__ = ["UnitCandidate", "collapse_units_to_chunks", "select_units_for_rerank"]

--- a/mem-knowledge/src/rag/retrieval/weighted_scoring.py
+++ b/mem-knowledge/src/rag/retrieval/weighted_scoring.py
@@ -1,0 +1,58 @@
+"""Candidate-corpus keyword cosine scoring, following Dify's weighted rerank."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from collections.abc import Sequence
+from threading import Lock
+from typing import TYPE_CHECKING
+
+from jieba import Tokenizer
+
+if TYPE_CHECKING:
+    from jieba.analyse import TFIDF
+
+_extractor: TFIDF | None = None
+_extractor_lock = Lock()
+
+
+def _keywords(text: str) -> list[str]:
+    global _extractor
+    # Initialize once inside the scoring worker, then share read-only dictionaries.
+    # Do not mutate Jieba's defaults or retain one full dictionary per pool thread.
+    if _extractor is None:
+        with _extractor_lock:
+            if _extractor is None:
+                from jieba.analyse import TFIDF
+
+                tokenizer = Tokenizer()
+                tokenizer.initialize()
+                extractor = TFIDF()
+                extractor.tokenizer = tokenizer
+                _extractor = extractor
+    return _extractor.extract_tags(text, topK=None)
+
+
+def keyword_similarities(query: str, texts: Sequence[str]) -> list[float]:
+    """Return TF-IDF cosine scores in input order, using one candidate corpus."""
+    if not texts:
+        return []
+    query_terms = Counter(_keywords(query))
+    documents = [Counter(_keywords(text)) for text in texts]
+    frequencies: Counter[str] = Counter()
+    for terms in documents:
+        frequencies.update(terms.keys())
+    idf = {
+        term: math.log((1 + len(documents)) / (1 + count)) + 1
+        for term, count in frequencies.items()
+    }
+    query_vector = {term: count * idf.get(term, 0.0) for term, count in query_terms.items()}
+    query_norm = math.sqrt(sum(value * value for value in query_vector.values()))
+    scores: list[float] = []
+    for terms in documents:
+        vector = {term: count * idf[term] for term, count in terms.items()}
+        norm = math.sqrt(sum(value * value for value in vector.values()))
+        numerator = sum(value * query_vector.get(term, 0.0) for term, value in vector.items())
+        scores.append(min(1.0, numerator / (norm * query_norm)) if norm and query_norm else 0.0)
+    return scores

--- a/mem-knowledge/src/rag/vdb/field.py
+++ b/mem-knowledge/src/rag/vdb/field.py
@@ -26,3 +26,10 @@ class Field(StrEnum):
     ANSWER = "answer"
     SOURCE_CHUNK_ID = "source_chunk_id"
     PARENT_ID = "parent_id"
+    # Retrieval-unit fields (multimodal qwen3-vl indexes only).
+    UNIT_ID = "unit_id"
+    UNIT_KIND = "unit_kind"
+    UNIT_INDEX = "unit_index"
+    CHUNK_ID = "chunk_id"
+    RETURN_CHUNK_ID = "return_chunk_id"
+    ASSET_FILE_ID = "asset_file_id"

--- a/mem-knowledge/src/rag/vdb/vector_store.py
+++ b/mem-knowledge/src/rag/vdb/vector_store.py
@@ -14,13 +14,15 @@ from redbear_model import (
     EmbeddingPurpose,
     EmbeddingRequest,
     ImageEmbeddingContent,
+    TextEmbeddingContent,
 )
 
 from ..models.chunk import DocumentChunk, chunk_retrieval_content
-from ..models.embedding import (
-    PreparedChunk,
-    collect_asset_file_ids,
-    prepare_chunk_embedding_contents,
+from ..models.embedding import collect_asset_file_ids
+from ..models.retrieval_unit import (
+    RetrievalUnit,
+    RetrievalUnitKind,
+    build_retrieval_units,
 )
 from .field import Field
 
@@ -70,6 +72,8 @@ class TaskVectorStore:
 
         if not chunks:
             return PreparedChunkBatch(actions=(), chunk_count=0)
+        if self._structured_multimodal:
+            return self._prepare_multimodal_units(chunks)
         vectors = self._embed_chunks(chunks)
         actions = []
         for chunk, vector in zip(chunks, vectors, strict=True):
@@ -90,6 +94,83 @@ class TaskVectorStore:
                     source[field.value] = metadata[field.value]
             actions.append({"_index": self._collection_name, "_source": source})
         return PreparedChunkBatch(actions=tuple(actions), chunk_count=len(chunks))
+
+    def _prepare_multimodal_units(self, chunks: list[DocumentChunk]) -> PreparedChunkBatch:
+        """Expand each chunk into retrieval units and embed text/image units."""
+
+        requested_ids = collect_asset_file_ids(chunks)
+        images = (
+            self._image_resolver(requested_ids, phase="index")
+            if requested_ids and self._image_resolver is not None
+            else {}
+        )
+        units_with_vectors: list[tuple[RetrievalUnit, list[float] | None]] = []
+        for chunk in chunks:
+            units = build_retrieval_units(chunk, images)
+            vectors = self._embed_units(units, chunk, images)
+            if len(vectors) != len(units):
+                raise RuntimeError("Unit embedding count does not match unit count")
+            units_with_vectors.extend(zip(units, vectors, strict=True))
+        actions = []
+        for unit, vector in units_with_vectors:
+            source: dict[str, Any] = {
+                Field.UNIT_ID.value: unit.unit_id,
+                Field.UNIT_KIND.value: unit.kind.value,
+                Field.UNIT_INDEX.value: unit.unit_index,
+                Field.CHUNK_ID.value: unit.chunk_id,
+                Field.RETURN_CHUNK_ID.value: unit.return_chunk_id,
+                Field.CONTENT_KEY.value: unit.content,
+                Field.METADATA_KEY.value: unit.metadata,
+                Field.VECTOR.value: vector,
+            }
+            if unit.asset_file_id is not None:
+                source[Field.ASSET_FILE_ID.value] = unit.asset_file_id
+            for field in (
+                Field.CHUNK_TYPE,
+                Field.QUESTION,
+                Field.ANSWER,
+                Field.SOURCE_CHUNK_ID,
+                Field.PARENT_ID,
+            ):
+                if unit.metadata.get(field.value):
+                    source[field.value] = unit.metadata[field.value]
+            actions.append({"_id": unit.unit_id, "_index": self._collection_name, "_source": source})
+        return PreparedChunkBatch(actions=tuple(actions), chunk_count=len(units_with_vectors))
+
+    def _embed_units(
+        self,
+        units: list[RetrievalUnit],
+        chunk: DocumentChunk,
+        images: Mapping[str, ImageEmbeddingContent],
+    ) -> list[list[float] | None]:
+        """Embed each text/image unit with a single-content fusion request."""
+
+        vectors: list[list[float] | None] = [None] * len(units)
+        for index, unit in enumerate(units):
+            contents = self._unit_embedding_contents(unit, images)
+            if not contents:
+                continue
+            result = self._embeddings.embed_contents(
+                EmbeddingRequest(purpose=EmbeddingPurpose.INDEX, contents=contents)
+            )
+            vector = list(result.vector)
+            expected = self._embedding_dimension or result.dimension
+            if len(vector) != expected or not all(math.isfinite(v) for v in vector):
+                raise RuntimeError("Embedding result has an invalid vector")
+            vectors[index] = vector
+        return vectors
+
+    @staticmethod
+    def _unit_embedding_contents(
+        unit: RetrievalUnit,
+        images: Mapping[str, ImageEmbeddingContent],
+    ) -> tuple:
+        if unit.kind is RetrievalUnitKind.TEXT:
+            return (TextEmbeddingContent(text=unit.content),) if unit.content.strip() else ()
+        if unit.kind is RetrievalUnitKind.IMAGE:
+            image = images.get(unit.asset_file_id or "")
+            return (image,) if image is not None else ()
+        return ()
 
     def write_prepared_batches(self, batches: list[PreparedChunkBatch]) -> None:
         """Validate every prepared batch before the first Elasticsearch write."""
@@ -173,8 +254,8 @@ class TaskVectorStore:
         return total, [self._hit_to_chunk(hit) for hit in hits]
 
     def _embed_chunks(self, chunks: list[DocumentChunk]) -> list[list[float] | None]:
-        if self._structured_multimodal:
-            return self._embed_multimodal_chunks(chunks)
+        """Embed text chunks for the non-multimodal (plain text) write path."""
+
         positions = []
         texts = []
         vectors: list[list[float] | None] = [None] * len(chunks)
@@ -203,50 +284,6 @@ class TaskVectorStore:
             vectors[position] = vector
         return vectors
 
-    def _embed_multimodal_chunks(
-        self,
-        chunks: list[DocumentChunk],
-    ) -> list[list[float] | None]:
-        prepared_chunks = self._prepare_multimodal_chunks(chunks)
-        vectors: list[list[float] | None] = [None] * len(chunks)
-        for index, prepared in enumerate(prepared_chunks):
-            if not prepared.embedding_contents:
-                continue
-            result = self._embeddings.embed_contents(
-                EmbeddingRequest(
-                    purpose=EmbeddingPurpose.INDEX,
-                    contents=prepared.embedding_contents,
-                )
-            )
-            vector = list(result.vector)
-            expected_dimension = self._embedding_dimension or result.dimension
-            if len(vector) != expected_dimension or not all(
-                math.isfinite(value) for value in vector
-            ):
-                raise RuntimeError("Embedding result has an invalid vector")
-            vectors[index] = vector
-        return vectors
-
-    def _prepare_multimodal_chunks(
-        self,
-        chunks: list[DocumentChunk],
-    ) -> list[PreparedChunk]:
-        requested_ids = collect_asset_file_ids(chunks)
-        images = (
-            self._image_resolver(requested_ids, phase="index")
-            if requested_ids and self._image_resolver is not None
-            else {}
-        )
-        result: list[PreparedChunk] = []
-        for chunk in chunks:
-            result.append(
-                PreparedChunk(
-                    chunk=chunk,
-                    embedding_contents=prepare_chunk_embedding_contents(chunk, images),
-                )
-            )
-        return result
-
     @staticmethod
     def _validate_embedding_count(embedded: list[Any], expected: int) -> None:
         if len(embedded) != expected:
@@ -258,57 +295,64 @@ class TaskVectorStore:
             if sample is not None
             else (self._embedding_dimension or 768)
         )
+        # Both plain-text and multimodal (unit) indexes use HNSW now; multimodal
+        # units are per-unit 2048-dim vectors, no longer a fused non-indexed blob.
         vector_mapping: dict[str, Any] = {
             "type": "dense_vector",
             "dims": dimensions,
-            "index": not self._structured_multimodal,
+            "index": True,
+            "similarity": "cosine",
         }
-        if not self._structured_multimodal:
-            vector_mapping["similarity"] = "cosine"
+        properties: dict[str, Any] = {
+            Field.CONTENT_KEY.value: {
+                "type": "text",
+                "analyzer": "ik_max_word",
+            },
+            Field.METADATA_KEY.value: {
+                "type": "object",
+                "properties": {
+                    "doc_id": {"type": "keyword"},
+                    "file_id": {"type": "keyword"},
+                    "file_name": {"type": "keyword"},
+                    "file_created_at": {
+                        "type": "date",
+                        "format": "epoch_millis",
+                    },
+                    "document_id": {"type": "keyword"},
+                    "knowledge_id": {"type": "keyword"},
+                    "sort_id": {"type": "long"},
+                    "status": {"type": "integer"},
+                    "parent_id": {"type": "keyword"},
+                    "asset_file_ids": {"type": "keyword"},
+                    "vision_text": {
+                        "type": "text",
+                        "analyzer": "ik_max_word",
+                    },
+                },
+            },
+            Field.VECTOR.value: vector_mapping,
+            Field.CHUNK_TYPE.value: {"type": "keyword"},
+            Field.QUESTION.value: {
+                "type": "text",
+                "analyzer": "ik_max_word",
+            },
+            Field.ANSWER.value: {
+                "type": "text",
+                "analyzer": "ik_max_word",
+            },
+            Field.SOURCE_CHUNK_ID.value: {"type": "keyword"},
+            Field.PARENT_ID.value: {"type": "keyword"},
+        }
+        if self._structured_multimodal:
+            properties[Field.UNIT_ID.value] = {"type": "keyword"}
+            properties[Field.UNIT_KIND.value] = {"type": "keyword"}
+            properties[Field.UNIT_INDEX.value] = {"type": "long"}
+            properties[Field.CHUNK_ID.value] = {"type": "keyword"}
+            properties[Field.RETURN_CHUNK_ID.value] = {"type": "keyword"}
+            properties[Field.ASSET_FILE_ID.value] = {"type": "keyword"}
         self._client.indices.create(
             index=self._collection_name,
-            mappings={
-                "properties": {
-                    Field.CONTENT_KEY.value: {
-                        "type": "text",
-                        "analyzer": "ik_max_word",
-                    },
-                    Field.METADATA_KEY.value: {
-                        "type": "object",
-                        "properties": {
-                            "doc_id": {"type": "keyword"},
-                            "file_id": {"type": "keyword"},
-                            "file_name": {"type": "keyword"},
-                            "file_created_at": {
-                                "type": "date",
-                                "format": "epoch_millis",
-                            },
-                            "document_id": {"type": "keyword"},
-                            "knowledge_id": {"type": "keyword"},
-                            "sort_id": {"type": "long"},
-                            "status": {"type": "integer"},
-                            "parent_id": {"type": "keyword"},
-                            "asset_file_ids": {"type": "keyword"},
-                            "vision_text": {
-                                "type": "text",
-                                "analyzer": "ik_max_word",
-                            },
-                        },
-                    },
-                    Field.VECTOR.value: vector_mapping,
-                    Field.CHUNK_TYPE.value: {"type": "keyword"},
-                    Field.QUESTION.value: {
-                        "type": "text",
-                        "analyzer": "ik_max_word",
-                    },
-                    Field.ANSWER.value: {
-                        "type": "text",
-                        "analyzer": "ik_max_word",
-                    },
-                    Field.SOURCE_CHUNK_ID.value: {"type": "keyword"},
-                    Field.PARENT_ID.value: {"type": "keyword"},
-                }
-            },
+            mappings={"properties": properties},
             settings={"index": {"refresh_interval": "1s"}},
         )
 

--- a/mem-knowledge/src/rag/vdb/vector_store.py
+++ b/mem-knowledge/src/rag/vdb/vector_store.py
@@ -134,7 +134,13 @@ class TaskVectorStore:
             ):
                 if unit.metadata.get(field.value):
                     source[field.value] = unit.metadata[field.value]
-            actions.append({"_id": unit.unit_id, "_index": self._collection_name, "_source": source})
+            actions.append(
+                {
+                    "_id": unit.unit_id,
+                    "_index": self._collection_name,
+                    "_source": source,
+                }
+            )
         return PreparedChunkBatch(actions=tuple(actions), chunk_count=len(units_with_vectors))
 
     def _embed_units(
@@ -295,14 +301,17 @@ class TaskVectorStore:
             if sample is not None
             else (self._embedding_dimension or 768)
         )
-        # Both plain-text and multimodal (unit) indexes use HNSW now; multimodal
-        # units are per-unit 2048-dim vectors, no longer a fused non-indexed blob.
+        # Multimodal qwen3-vl emits 2048-dim vectors; this ES version (8.7) caps
+        # indexed dense_vector at 1024 dims, so unit vectors stay non-indexed and
+        # recall uses script_score cosine (same as the legacy fused path). Plain
+        # text KBs keep HNSW. (HNSW for units is a future ES-upgrade follow-up.)
         vector_mapping: dict[str, Any] = {
             "type": "dense_vector",
             "dims": dimensions,
-            "index": True,
-            "similarity": "cosine",
+            "index": not self._structured_multimodal,
         }
+        if not self._structured_multimodal:
+            vector_mapping["similarity"] = "cosine"
         properties: dict[str, Any] = {
             Field.CONTENT_KEY.value: {
                 "type": "text",

--- a/mem-knowledge/src/services/chunk.py
+++ b/mem-knowledge/src/services/chunk.py
@@ -571,8 +571,8 @@ def build_chunk_store(
         embed_unit_contents=embed_unit_contents,
         image_resolver=image_resolver,
         embedding_dimension=embedding_dimension,
-        # Unit indexes are HNSW-backed for both plain-text and multimodal KBs.
-        vector_indexed=True,
+        # Match worker indexes: multimodal vectors use script_score recall.
+        vector_indexed=not multimodal,
         multimodal=multimodal,
     )
 

--- a/mem-knowledge/src/services/chunk.py
+++ b/mem-knowledge/src/services/chunk.py
@@ -522,20 +522,27 @@ def build_chunk_store(
     client: Any,
     snapshot: ChunkDocumentSnapshot,
     resolved_embedding: ResolvedModelConfig | None = None,
+    *,
+    for_mutation: bool = True,
 ) -> AsyncChunkStore:
     embed = None
     embed_chunks = None
     embed_unit_contents = None
     image_resolver = None
     embedding_dimension = None
-    if resolved_embedding is not None:
+    multimodal = (
+        resolved_embedding is not None and is_qwen3_vl_embedding(resolved_embedding)
+    )
+    # Read-only paths (e.g. chunk listing) only need the multimodal marker to
+    # collapse unit docs; skip building the embedding model client entirely.
+    if resolved_embedding is not None and for_mutation:
         from redbear_model.runtime import RedBearEmbeddings
 
         model = RedBearEmbeddings(
             resolved_embedding,
             client_pool=runtime.model_runtime.pool,
         )
-        if is_qwen3_vl_embedding(resolved_embedding):
+        if multimodal:
             embedding_dimension = QWEN3_VL_EMBEDDING_DIMENSION
 
             async def embed_unit_contents(contents: list[Any]) -> Any:
@@ -566,6 +573,7 @@ def build_chunk_store(
         embedding_dimension=embedding_dimension,
         # Unit indexes are HNSW-backed for both plain-text and multimodal KBs.
         vector_indexed=True,
+        multimodal=multimodal,
     )
 
 

--- a/mem-knowledge/src/services/chunk.py
+++ b/mem-knowledge/src/services/chunk.py
@@ -27,10 +27,6 @@ from ..models.owned import Document
 from ..rag.chunk.metadata import merge_parser_metadata
 from ..rag.chunk.preview import preview_binary
 from ..rag.models.chunk import DocumentChunk
-from ..rag.models.embedding import (
-    collect_asset_file_ids,
-    prepare_chunk_embedding_contents,
-)
 from ..rag.retrieval.async_elasticsearch import AsyncChunkStore
 from ..repositories.model_registry import AsyncSQLModelRegistry
 from ..runtime import ProcessRuntime
@@ -529,6 +525,8 @@ def build_chunk_store(
 ) -> AsyncChunkStore:
     embed = None
     embed_chunks = None
+    embed_unit_contents = None
+    image_resolver = None
     embedding_dimension = None
     if resolved_embedding is not None:
         from redbear_model.runtime import RedBearEmbeddings
@@ -540,32 +538,22 @@ def build_chunk_store(
         if is_qwen3_vl_embedding(resolved_embedding):
             embedding_dimension = QWEN3_VL_EMBEDDING_DIMENSION
 
-            async def embed_multimodal_chunks(
-                chunks: list[DocumentChunk],
-            ) -> list[list[float] | None]:
-                asset_ids = collect_asset_file_ids(chunks)
-                images = await resolve_storage_images_async(
+            async def embed_unit_contents(contents: list[Any]) -> Any:
+                result = await model.aembed_contents(
+                    EmbeddingRequest(
+                        purpose=EmbeddingPurpose.INDEX,
+                        contents=tuple(contents),
+                    )
+                )
+                return list(result.vector)
+
+            async def image_resolver(asset_ids: list[str]) -> dict[str, Any]:
+                return await resolve_storage_images_async(
                     runtime,
                     snapshot.knowledge_id,
                     asset_ids,
                     phase="index",
                 )
-                vectors: list[list[float] | None] = []
-                for chunk in chunks:
-                    contents = prepare_chunk_embedding_contents(chunk, images)
-                    if not contents:
-                        vectors.append(None)
-                        continue
-                    result = await model.aembed_contents(
-                        EmbeddingRequest(
-                            purpose=EmbeddingPurpose.INDEX,
-                            contents=contents,
-                        )
-                    )
-                    vectors.append(list(result.vector))
-                return vectors
-
-            embed_chunks = embed_multimodal_chunks
         else:
             embed = model.aembed_documents
     return AsyncChunkStore(
@@ -573,10 +561,11 @@ def build_chunk_store(
         snapshot.knowledge_id,
         embed=embed,
         embed_chunks=embed_chunks,
+        embed_unit_contents=embed_unit_contents,
+        image_resolver=image_resolver,
         embedding_dimension=embedding_dimension,
-        vector_indexed=not is_qwen3_vl_embedding(resolved_embedding)
-        if resolved_embedding is not None
-        else True,
+        # Unit indexes are HNSW-backed for both plain-text and multimodal KBs.
+        vector_indexed=True,
     )
 
 

--- a/mem-knowledge/src/services/knowledge_retrieval.py
+++ b/mem-knowledge/src/services/knowledge_retrieval.py
@@ -1100,7 +1100,6 @@ class KnowledgeRetrievalService:
                 "Image query requires qwen3-vl rerank",
             )
 
-        asset_ids = [c.asset_file_id for c in candidates if c.asset_file_id]
         asset_ids_by_kb: dict[uuid.UUID, list[str]] = {}
         for candidate in candidates:
             if not candidate.asset_file_id:

--- a/mem-knowledge/src/services/knowledge_retrieval.py
+++ b/mem-knowledge/src/services/knowledge_retrieval.py
@@ -510,6 +510,7 @@ class KnowledgeRetrievalService:
                     full_text_options,
                 )
                 chunks = collapse_units_to_chunks(unit_candidates)
+                chunks = await store.resolve_parent_chunks(chunks, target.index_name)
             else:
                 chunks = await store.search_by_full_text(text_query, full_text_options)
             cls._log_target_done(
@@ -562,6 +563,7 @@ class KnowledgeRetrievalService:
                         vector_options,
                     )
                     chunks = collapse_units_to_chunks(unit_candidates)
+                    chunks = await store.resolve_parent_chunks(chunks, target.index_name)
                 else:
                     chunks = await store.search_by_query_vector(
                         query_vector,
@@ -582,6 +584,7 @@ class KnowledgeRetrievalService:
                         vector_options,
                     )
                     chunks = collapse_units_to_chunks(unit_candidates)
+                    chunks = await store.resolve_parent_chunks(chunks, target.index_name)
                 else:
                     chunks = await store.search_by_vector(embedding, text_query, vector_options)
             cls._log_target_done(
@@ -742,18 +745,29 @@ class KnowledgeRetrievalService:
             )
         finally:
             cls._record_timing(timings, "local_rerank_ms", local_rerank_started_at)
+        # Parent-child mode: swap child hits for their parents so callers receive
+        # the parent block. merge_parent_chunks carries the child score onto the
+        # parent's metadata.score, so the resolved chunk already has its score.
+        ranked_chunks = await store.resolve_parent_chunks(
+            [candidate.chunk for candidate in ranked],
+            target.index_name,
+        )
+        resolved_ranked = [
+            cls._candidate_from_resolved_chunk(chunk, target.knowledge_id, index)
+            for index, chunk in enumerate(ranked_chunks)
+        ]
         cls._log_target_done(
             target,
             len(vector_chunks),
             len(text_chunks),
             len(candidates),
-            len(ranked),
+            len(resolved_ranked),
             started_at,
             local_rerank=True,
             timings=timings,
         )
         return TargetRetrievalResult(
-            candidates=tuple(ranked),
+            candidates=tuple(resolved_ranked),
             entities=tuple(graph_result.entities),
             relationships=tuple(graph_result.relationships),
         )
@@ -1064,6 +1078,26 @@ class KnowledgeRetrievalService:
 
         query_vector = normalize_vector(await embedding.aembed_query(text_query))
         return await store.search_units_by_vector(query_vector, options)
+
+    @staticmethod
+    def _candidate_from_resolved_chunk(
+        chunk: DocumentChunk,
+        knowledge_id: uuid.UUID,
+        arrival_index: int,
+    ) -> RetrievalCandidate:
+        """Rebuild a candidate after parent resolution, keeping its score."""
+
+        score = (chunk.metadata or {}).get("score")
+        final = float(score) if score is not None else None
+        return RetrievalCandidate(
+            chunk=chunk,
+            knowledge_id=knowledge_id,
+            semantic_score=None,
+            participle_score=None,
+            graph_score=None,
+            final_score=final,
+            arrival_index=arrival_index,
+        )
 
     @staticmethod
     def _unit_to_chunk(candidate: UnitCandidate) -> DocumentChunk:

--- a/mem-knowledge/src/services/knowledge_retrieval.py
+++ b/mem-knowledge/src/services/knowledge_retrieval.py
@@ -502,7 +502,16 @@ class KnowledgeRetrievalService:
                     "KB_VALIDATION_ERROR",
                     "Image query does not support participle retrieval",
                 )
-            chunks = await store.search_by_full_text(text_query, full_text_options)
+            if is_qwen3_vl_embedding(target.embedding.resolved):
+                # Multimodal KB stores units: full-text hits text units only,
+                # then collapse back to chunks (single-channel, no rerank).
+                unit_candidates = await store.search_units_full_text(
+                    text_query,
+                    full_text_options,
+                )
+                chunks = collapse_units_to_chunks(unit_candidates)
+            else:
+                chunks = await store.search_by_full_text(text_query, full_text_options)
             cls._log_target_done(
                 target,
                 0,

--- a/mem-knowledge/src/services/knowledge_retrieval.py
+++ b/mem-knowledge/src/services/knowledge_retrieval.py
@@ -564,7 +564,17 @@ class KnowledgeRetrievalService:
                         "KB_VALIDATION_ERROR",
                         "Text query content is unavailable",
                     )
-                chunks = await store.search_by_vector(embedding, text_query, vector_options)
+                if is_qwen3_vl_embedding(target.embedding.resolved):
+                    # Multimodal KB: text query recalls text units (image chunks
+                    # surface via their vision_text text unit), then collapse.
+                    query_vector = normalize_vector(await embedding.aembed_query(text_query))
+                    unit_candidates = await store.search_units_by_vector(
+                        query_vector,
+                        vector_options,
+                    )
+                    chunks = collapse_units_to_chunks(unit_candidates)
+                else:
+                    chunks = await store.search_by_vector(embedding, text_query, vector_options)
             cls._log_target_done(
                 target,
                 len(chunks),
@@ -614,12 +624,21 @@ class KnowledgeRetrievalService:
                     "KB_VALIDATION_ERROR",
                     "Text query content is unavailable",
                 )
-            vector_task = asyncio.create_task(
-                store.search_by_vector(embedding, text_query, vector_options)
-            )
-            text_task = asyncio.create_task(
-                store.search_by_full_text(text_query, full_text_options)
-            )
+            multimodal_kb = is_qwen3_vl_embedding(target.embedding.resolved)
+            if multimodal_kb:
+                vector_task = asyncio.create_task(
+                    cls._search_units_by_text(embedding, store, text_query, vector_options)
+                )
+                text_task = asyncio.create_task(
+                    store.search_units_full_text(text_query, full_text_options)
+                )
+            else:
+                vector_task = asyncio.create_task(
+                    store.search_by_vector(embedding, text_query, vector_options)
+                )
+                text_task = asyncio.create_task(
+                    store.search_by_full_text(text_query, full_text_options)
+                )
             graph_task = (
                 asyncio.create_task(
                     cls._retrieve_evidence_graph_channel(
@@ -653,6 +672,9 @@ class KnowledgeRetrievalService:
 
             vector_chunks = gathered[0]
             text_chunks = gathered[1]
+            if multimodal_kb:
+                vector_chunks = [cls._unit_to_chunk(uc) for uc in vector_chunks]
+                text_chunks = [cls._unit_to_chunk(uc) for uc in text_chunks]
             graph_result = (
                 gathered[2] if graph_task is not None else KnowledgeRetrievalResult()
             )
@@ -1021,6 +1043,18 @@ class KnowledgeRetrievalService:
             chunk.metadata["score"] = float(item.metadata.get("relevance_score") or 0)
             result.append(chunk)
         return ModelRerankResult(chunks=tuple(result), used_fallback=False)
+
+    @staticmethod
+    async def _search_units_by_text(
+        embedding: Any,
+        store: Any,
+        text_query: str,
+        options: RetrievalSearchOptions,
+    ) -> list[UnitCandidate]:
+        """Embed a text query and recall text units from a multimodal index."""
+
+        query_vector = normalize_vector(await embedding.aembed_query(text_query))
+        return await store.search_units_by_vector(query_vector, options)
 
     @staticmethod
     def _unit_to_chunk(candidate: UnitCandidate) -> DocumentChunk:

--- a/mem-knowledge/src/services/knowledge_retrieval.py
+++ b/mem-knowledge/src/services/knowledge_retrieval.py
@@ -43,7 +43,9 @@ from ..rag.retrieval.async_elasticsearch import AsyncElasticSearchRetrieval
 from ..rag.retrieval.candidates import (
     RetrievalChannel,
     candidate_from_chunk,
+    collapse_ranked_candidates,
     deduplicate_candidates_first_win,
+    has_unit_candidates,
     materialize_candidates,
     merge_candidates,
 )
@@ -85,6 +87,9 @@ _MAX_RETRIEVAL_WORKERS = 3
 _MAX_MULTIMODAL_RERANK_TEXT_VIEWS = 100
 _MAX_MULTIMODAL_RERANK_IMAGE_VIEWS = 40
 _UNIT_CONTENT = "_unit_content"
+_UNIT_METADATA_KEYS = (
+    _UNIT_CONTENT, "_unit_id", "_unit_kind", "_chunk_id", "_return_chunk_id", "_asset_file_id",
+)
 
 
 def _record_elapsed(
@@ -564,8 +569,7 @@ class KnowledgeRetrievalService:
                         query_vector,
                         vector_options,
                     )
-                    chunks = collapse_units_to_chunks(unit_candidates)
-                    chunks = await store.resolve_parent_chunks(chunks, target.index_name)
+                    chunks = [cls._unit_to_chunk(candidate) for candidate in unit_candidates]
                 else:
                     chunks = await store.search_by_query_vector(
                         query_vector,
@@ -578,15 +582,13 @@ class KnowledgeRetrievalService:
                         "Text query content is unavailable",
                     )
                 if is_qwen3_vl_embedding(target.embedding.resolved):
-                    # Multimodal KB: text query recalls text units (image chunks
-                    # surface via their vision_text text unit), then collapse.
+                    # Keep unit identity for any subsequent global ranking stage.
                     query_vector = normalize_vector(await embedding.aembed_query(text_query))
                     unit_candidates = await store.search_units_by_vector(
                         query_vector,
                         vector_options,
                     )
-                    chunks = collapse_units_to_chunks(unit_candidates)
-                    chunks = await store.resolve_parent_chunks(chunks, target.index_name)
+                    chunks = [cls._unit_to_chunk(candidate) for candidate in unit_candidates]
                 else:
                     chunks = await store.search_by_vector(embedding, text_query, vector_options)
             cls._log_target_done(
@@ -965,6 +967,8 @@ class KnowledgeRetrievalService:
             if len(targets) == 1 and targets[0].params.retrieve_type is not RetrieveType.HYBRID
             else request.top_k
         )
+        if has_unit_candidates(ranked):
+            ranked = collapse_ranked_candidates(ranked)
         result_candidates = ranked[:top_k]
         result = materialize_candidates(result_candidates)
         if store is not None:
@@ -972,7 +976,8 @@ class KnowledgeRetrievalService:
                 store, result_candidates, result, targets,
             )
         for chunk in result:
-            chunk.metadata.pop(_UNIT_CONTENT, None)
+            for key in _UNIT_METADATA_KEYS:
+                chunk.metadata.pop(key, None)
         cls._log_finalize(
             log_id,
             candidates_count,
@@ -1294,8 +1299,11 @@ class KnowledgeRetrievalService:
                 replace(unit, score=score.relevance_score)
             )
 
-        collapsed = collapse_units_to_chunks(scored_units)
-        return ModelRerankResult(chunks=tuple(collapsed[:top_k]), used_fallback=False)
+        ranked_units = sorted(scored_units, key=lambda unit: -unit.score)
+        return ModelRerankResult(
+            chunks=tuple(cls._unit_to_chunk(unit) for unit in ranked_units[:top_k]),
+            used_fallback=False,
+        )
 
     @staticmethod
     def _seed_model_fallback_scores(

--- a/mem-knowledge/src/services/knowledge_retrieval.py
+++ b/mem-knowledge/src/services/knowledge_retrieval.py
@@ -123,9 +123,15 @@ def _record_elapsed(
 class _TimedElasticSearchRetrieval(AsyncElasticSearchRetrieval):
     """Record oracle-compatible phases without owning another ES client."""
 
-    def __init__(self, client: Any, timings: RetrievalTimings | None) -> None:
+    def __init__(
+        self,
+        client: Any,
+        timings: RetrievalTimings | None,
+        *,
+        track_parent_matches: bool = False,
+    ) -> None:
         self._timings = timings
-        super().__init__(client)
+        super().__init__(client, track_parent_matches=track_parent_matches)
 
     async def search_by_vector(
         self,
@@ -279,7 +285,13 @@ class KnowledgeRetrievalService:
             )
 
         client = await runtime.elasticsearch.client()
-        store = _TimedElasticSearchRetrieval(client, timings)
+        store = _TimedElasticSearchRetrieval(
+            client,
+            timings,
+            track_parent_matches=bool(
+                preparation.global_rerank and preparation.global_rerank.recompute_keywords
+            ),
+        )
         retrieval_result = await cls._retrieve_prepared(
             runtime,
             client,
@@ -374,6 +386,7 @@ class KnowledgeRetrievalService:
                         and target.params.retrieve_type is RetrieveType.HYBRID
                     ),
                     request_reranker=preparation.request_reranker,
+                    global_rerank=preparation.global_rerank,
                     image_query=image_query,
                     timings=timings,
                     log_id=log_id,
@@ -459,6 +472,7 @@ class KnowledgeRetrievalService:
         graph_target: GraphTargetSnapshot | None,
         use_request_reranker: bool = False,
         request_reranker: ModelRuntimeSnapshot | None = None,
+        global_rerank: RerankPlan | None = None,
         image_query: ImageEmbeddingContent | None = None,
         timings: RetrievalTimings | None = None,
         log_id: str | None = None,
@@ -602,6 +616,12 @@ class KnowledgeRetrievalService:
                 )
             )
 
+        weighted_semantics = bool(
+            global_rerank
+            and global_rerank.recompute_keywords
+            and global_rerank.weights.semantic_weight > 0
+        )
+        query_vector: list[float] | None = None
         if image_query is not None:
             query_vector = await cls._embed_image_query(
                 embedding,
@@ -621,9 +641,18 @@ class KnowledgeRetrievalService:
                     "KB_VALIDATION_ERROR",
                     "Text query content is unavailable",
                 )
-            vector_task = asyncio.create_task(
-                store.search_by_vector(embedding, text_query, vector_options)
-            )
+            async def search_vector() -> list[DocumentChunk]:
+                nonlocal query_vector
+                if not weighted_semantics:
+                    return await store.search_by_vector(embedding, text_query, vector_options)
+                embedding_started_at = time.perf_counter()
+                try:
+                    query_vector = normalize_vector(await embedding.aembed_query(text_query))
+                finally:
+                    cls._record_timing(timings, "embedding_ms", embedding_started_at)
+                return await store.search_by_query_vector(query_vector, vector_options)
+
+            vector_task = asyncio.create_task(search_vector())
             text_task = asyncio.create_task(
                 store.search_by_full_text(text_query, full_text_options)
             )
@@ -718,6 +747,27 @@ class KnowledgeRetrievalService:
             )
         finally:
             cls._record_timing(timings, "local_rerank_ms", local_rerank_started_at)
+        if weighted_semantics and query_vector is not None:
+            missing = [candidate for candidate in ranked if candidate.semantic_score is None]
+            if missing:
+                scoring_started_at = time.perf_counter()
+                try:
+                    scores = await store.score_candidates_by_vector(
+                        query_vector, [candidate.chunk for candidate in missing], vector_options
+                    )
+                finally:
+                    cls._record_timing(timings, "es_vector_ms", scoring_started_at)
+                ranked = [
+                    replace(
+                        candidate,
+                        semantic_score=scores.get(
+                            str((candidate.chunk.metadata or {}).get("doc_id") or ""), 0.0
+                        ),
+                    )
+                    if candidate.semantic_score is None
+                    else candidate
+                    for candidate in ranked
+                ]
         cls._log_target_done(
             target,
             len(vector_chunks),

--- a/mem-knowledge/src/services/knowledge_retrieval.py
+++ b/mem-knowledge/src/services/knowledge_retrieval.py
@@ -84,6 +84,7 @@ _SOURCE_INDEX = "_retrieval_source_index"
 _MAX_RETRIEVAL_WORKERS = 3
 _MAX_MULTIMODAL_RERANK_TEXT_VIEWS = 100
 _MAX_MULTIMODAL_RERANK_IMAGE_VIEWS = 40
+_UNIT_CONTENT = "_unit_content"
 
 
 def _record_elapsed(
@@ -970,6 +971,8 @@ class KnowledgeRetrievalService:
             result = await cls._resolve_final_parent_chunks(
                 store, result_candidates, result, targets,
             )
+        for chunk in result:
+            chunk.metadata.pop(_UNIT_CONTENT, None)
         cls._log_finalize(
             log_id,
             candidates_count,
@@ -1126,6 +1129,7 @@ class KnowledgeRetrievalService:
             _return_chunk_id=candidate.return_chunk_id,
             score=candidate.score,
         )
+        metadata[_UNIT_CONTENT] = candidate.content
         if candidate.asset_file_id is not None:
             metadata["_asset_file_id"] = candidate.asset_file_id
         chunk.metadata = metadata
@@ -1148,6 +1152,7 @@ class KnowledgeRetrievalService:
             score = float(metadata.get("score") or 0)
             chunk_id = str(metadata.get("_chunk_id") or metadata.get("doc_id") or "")
             kind_raw = metadata.get("_unit_kind") or RetrievalUnitKind.TEXT.value
+            unit_content = metadata.get(_UNIT_CONTENT)
             candidates.append(
                 UnitCandidate(
                     unit_id=str(metadata.get("_unit_id") or f"{chunk_id}:text"),
@@ -1159,7 +1164,7 @@ class KnowledgeRetrievalService:
                     ),
                     kind=RetrievalUnitKind(kind_raw),
                     asset_file_id=metadata.get("_asset_file_id"),
-                    content=chunk.page_content,
+                    content=unit_content if isinstance(unit_content, str) else chunk.page_content,
                     score=score,
                     chunk=chunk,
                 )

--- a/mem-knowledge/src/services/knowledge_retrieval.py
+++ b/mem-knowledge/src/services/knowledge_retrieval.py
@@ -396,6 +396,7 @@ class KnowledgeRetrievalService:
             request,
             preparation,
             candidates,
+            store=store,
             image_query=image_query,
             timings=timings,
             log_id=log_id,
@@ -745,29 +746,18 @@ class KnowledgeRetrievalService:
             )
         finally:
             cls._record_timing(timings, "local_rerank_ms", local_rerank_started_at)
-        # Parent-child mode: swap child hits for their parents so callers receive
-        # the parent block. merge_parent_chunks carries the child score onto the
-        # parent's metadata.score, so the resolved chunk already has its score.
-        ranked_chunks = await store.resolve_parent_chunks(
-            [candidate.chunk for candidate in ranked],
-            target.index_name,
-        )
-        resolved_ranked = [
-            cls._candidate_from_resolved_chunk(chunk, target.knowledge_id, index)
-            for index, chunk in enumerate(ranked_chunks)
-        ]
         cls._log_target_done(
             target,
             len(vector_chunks),
             len(text_chunks),
             len(candidates),
-            len(resolved_ranked),
+            len(ranked),
             started_at,
             local_rerank=True,
             timings=timings,
         )
         return TargetRetrievalResult(
-            candidates=tuple(resolved_ranked),
+            candidates=tuple(ranked),
             entities=tuple(graph_result.entities),
             relationships=tuple(graph_result.relationships),
         )
@@ -897,6 +887,7 @@ class KnowledgeRetrievalService:
         preparation: RetrievalPreparation,
         candidates: Sequence[RetrievalCandidate],
         *,
+        store: AsyncElasticSearchRetrieval | None = None,
         image_query: ImageEmbeddingContent | None = None,
         timings: RetrievalTimings | None = None,
         log_id: str | None = None,
@@ -975,6 +966,10 @@ class KnowledgeRetrievalService:
         )
         result_candidates = ranked[:top_k]
         result = materialize_candidates(result_candidates)
+        if store is not None:
+            result = await cls._resolve_final_parent_chunks(
+                store, result_candidates, result, targets,
+            )
         cls._log_finalize(
             log_id,
             candidates_count,
@@ -1080,24 +1075,43 @@ class KnowledgeRetrievalService:
         return await store.search_units_by_vector(query_vector, options)
 
     @staticmethod
-    def _candidate_from_resolved_chunk(
-        chunk: DocumentChunk,
-        knowledge_id: uuid.UUID,
-        arrival_index: int,
-    ) -> RetrievalCandidate:
-        """Rebuild a candidate after parent resolution, keeping its score."""
+    async def _resolve_final_parent_chunks(
+        store: AsyncElasticSearchRetrieval,
+        candidates: Sequence[RetrievalCandidate],
+        chunks: list[DocumentChunk],
+        targets: Sequence[RetrievalTarget],
+    ) -> list[DocumentChunk]:
+        """Resolve parents only after all ranking, preserving final result order."""
 
-        score = (chunk.metadata or {}).get("score")
-        final = float(score) if score is not None else None
-        return RetrievalCandidate(
-            chunk=chunk,
-            knowledge_id=knowledge_id,
-            semantic_score=None,
-            participle_score=None,
-            graph_score=None,
-            final_score=final,
-            arrival_index=arrival_index,
-        )
+        children_by_kb: dict[uuid.UUID, list[DocumentChunk]] = {}
+        for candidate, chunk in zip(candidates, chunks, strict=True):
+            if chunk.metadata.get("chunk_type") == "child" and chunk.metadata.get("parent_id"):
+                children_by_kb.setdefault(candidate.knowledge_id, []).append(chunk)
+        if not children_by_kb:
+            return chunks
+        indices = {target.knowledge_id: target.index_name for target in targets}
+        resolved_by_id: dict[tuple[uuid.UUID, str], DocumentChunk] = {}
+        for knowledge_id, children in children_by_kb.items():
+            resolved = await store.resolve_parent_chunks(children, indices[knowledge_id])
+            for chunk in resolved:
+                resolved_by_id[(knowledge_id, str(chunk.metadata.get("doc_id")))] = chunk
+
+        result: list[DocumentChunk] = []
+        seen: set[tuple[uuid.UUID, str]] = set()
+        for candidate, chunk in zip(candidates, chunks, strict=True):
+            if chunk.metadata.get("chunk_type") == "child" and chunk.metadata.get("parent_id"):
+                parent = resolved_by_id.get(
+                    (candidate.knowledge_id, str(chunk.metadata["parent_id"]))
+                )
+                if parent is not None:
+                    parent = parent.model_copy(deep=True)
+                    parent.metadata["score"] = chunk.metadata["score"]
+                    chunk = parent
+            key = (candidate.knowledge_id, str(chunk.metadata.get("doc_id")))
+            if key not in seen:
+                seen.add(key)
+                result.append(chunk)
+        return result
 
     @staticmethod
     def _unit_to_chunk(candidate: UnitCandidate) -> DocumentChunk:

--- a/mem-knowledge/src/services/knowledge_retrieval.py
+++ b/mem-knowledge/src/services/knowledge_retrieval.py
@@ -10,7 +10,6 @@ from collections.abc import Sequence
 from dataclasses import replace
 from enum import Enum
 from functools import partial
-from itertools import islice, zip_longest
 from typing import Any
 
 from langchain_core.documents import Document as LangChainDocument
@@ -39,7 +38,7 @@ from ..rag.knowledge_graph.config import GraphPipeline
 from ..rag.metadata.auto_filter import generate_filter_groups
 from ..rag.metadata.filter_engine import FilterCondition, FilterGroup
 from ..rag.models.chunk import DocumentChunk, chunk_retrieval_content
-from ..rag.models.embedding import collect_asset_file_ids, sanitized_retrieval_text
+from ..rag.models.retrieval_unit import RetrievalUnitKind
 from ..rag.retrieval.async_elasticsearch import AsyncElasticSearchRetrieval
 from ..rag.retrieval.candidates import (
     RetrievalChannel,
@@ -71,6 +70,11 @@ from ..rag.retrieval.models import (
     TargetRetrievalResult,
 )
 from ..rag.retrieval.rerank import ModelRerankResult, RerankEngine
+from ..rag.retrieval.unit_collapse import (
+    UnitCandidate,
+    collapse_units_to_chunks,
+    select_units_for_rerank,
+)
 from ..runtime import ProcessRuntime
 from .knowledge_retrieval_preparation import KnowledgeRetrievalPreparation
 from .multimodal_image import resolve_storage_images_async, validate_image_data_uri
@@ -80,33 +84,6 @@ _SOURCE_INDEX = "_retrieval_source_index"
 _MAX_RETRIEVAL_WORKERS = 3
 _MAX_MULTIMODAL_RERANK_TEXT_VIEWS = 100
 _MAX_MULTIMODAL_RERANK_IMAGE_VIEWS = 40
-
-
-def _select_multimodal_rerank_views(
-    views: Sequence[RerankCandidateView],
-) -> list[RerankCandidateView]:
-    """Keep text in candidate order and distribute image slots across chunks."""
-    text_indices: list[int] = []
-    image_indices_by_chunk: dict[int, list[int]] = {}
-    for index, view in enumerate(views):
-        if view.kind == "text":
-            if len(text_indices) < _MAX_MULTIMODAL_RERANK_TEXT_VIEWS:
-                text_indices.append(index)
-        else:
-            image_indices_by_chunk.setdefault(view.chunk_index, []).append(index)
-
-    round_robin_image_indices = (
-        index
-        for layer in zip_longest(*image_indices_by_chunk.values())
-        for index in layer
-        if index is not None
-    )
-    selected_indices = set(text_indices)
-    selected_indices.update(
-        islice(round_robin_image_indices, _MAX_MULTIMODAL_RERANK_IMAGE_VIEWS)
-    )
-    # Preserve the original payload order and each view's source-chunk mapping.
-    return [view for index, view in enumerate(views) if index in selected_indices]
 
 
 def _record_elapsed(
@@ -570,10 +547,17 @@ class KnowledgeRetrievalService:
                     image_query,
                     timings,
                 )
-                chunks = await store.search_by_query_vector(
-                    query_vector,
-                    vector_options,
-                )
+                if is_qwen3_vl_embedding(target.embedding.resolved):
+                    unit_candidates = await store.search_units_by_vector(
+                        query_vector,
+                        vector_options,
+                    )
+                    chunks = collapse_units_to_chunks(unit_candidates)
+                else:
+                    chunks = await store.search_by_query_vector(
+                        query_vector,
+                        vector_options,
+                    )
             else:
                 if text_query is None:
                     raise KnowledgeError.from_code(
@@ -608,10 +592,19 @@ class KnowledgeRetrievalService:
                 image_query,
                 timings,
             )
-            vector_chunks = await store.search_by_query_vector(
-                query_vector,
-                vector_options,
-            )
+            if is_qwen3_vl_embedding(target.embedding.resolved):
+                unit_candidates = await store.search_units_by_vector(
+                    query_vector,
+                    vector_options,
+                )
+                vector_chunks = [
+                    cls._unit_to_chunk(uc) for uc in unit_candidates
+                ]
+            else:
+                vector_chunks = await store.search_by_query_vector(
+                    query_vector,
+                    vector_options,
+                )
             text_chunks = []
             graph_result = KnowledgeRetrievalResult()
             active_tasks = []
@@ -979,11 +972,12 @@ class KnowledgeRetrievalService:
         if top_k <= 0 or not chunks:
             return ModelRerankResult(chunks=(), used_fallback=False)
         if isinstance(query, ImageEmbeddingContent):
-            return await cls._rerank_multimodal_chunks(
+            unit_candidates = cls._chunks_to_unit_candidates(chunks)
+            return await cls._rerank_multimodal_units(
                 runtime,
                 snapshot,
                 query,
-                chunks,
+                unit_candidates,
                 top_k,
             )
         if snapshot.resolved is None:
@@ -1028,15 +1022,75 @@ class KnowledgeRetrievalService:
             result.append(chunk)
         return ModelRerankResult(chunks=tuple(result), used_fallback=False)
 
+    @staticmethod
+    def _unit_to_chunk(candidate: UnitCandidate) -> DocumentChunk:
+        """Materialize a unit candidate as a chunk carrying its unit identity."""
+
+        chunk = candidate.chunk.model_copy(deep=True)
+        metadata = dict(chunk.metadata or {})
+        metadata.update(
+            _unit_id=candidate.unit_id,
+            _unit_kind=candidate.kind.value,
+            _chunk_id=candidate.chunk_id,
+            _return_chunk_id=candidate.return_chunk_id,
+            score=candidate.score,
+        )
+        if candidate.asset_file_id is not None:
+            metadata["_asset_file_id"] = candidate.asset_file_id
+        chunk.metadata = metadata
+        return chunk
+
+    @staticmethod
+    def _chunks_to_unit_candidates(
+        chunks: Sequence[DocumentChunk],
+    ) -> list[UnitCandidate]:
+        """Rebuild unit candidates from unit-tagged chunks.
+
+        Multimodal unit recall tags each hit's metadata with ``_unit_*`` keys;
+        chunks lacking them are treated as plain text units (their content is
+        the retrieval text), keeping non-unit callers working.
+        """
+
+        candidates: list[UnitCandidate] = []
+        for chunk in chunks:
+            metadata = chunk.metadata or {}
+            score = float(metadata.get("score") or 0)
+            chunk_id = str(metadata.get("_chunk_id") or metadata.get("doc_id") or "")
+            kind_raw = metadata.get("_unit_kind") or RetrievalUnitKind.TEXT.value
+            candidates.append(
+                UnitCandidate(
+                    unit_id=str(metadata.get("_unit_id") or f"{chunk_id}:text"),
+                    chunk_id=chunk_id,
+                    return_chunk_id=str(
+                        metadata.get("_return_chunk_id")
+                        or metadata.get("parent_id")
+                        or chunk_id
+                    ),
+                    kind=RetrievalUnitKind(kind_raw),
+                    asset_file_id=metadata.get("_asset_file_id"),
+                    content=chunk.page_content,
+                    score=score,
+                    chunk=chunk,
+                )
+            )
+        return candidates
+
     @classmethod
-    async def _rerank_multimodal_chunks(
+    async def _rerank_multimodal_units(
         cls,
         runtime: ProcessRuntime,
         snapshot: ModelRuntimeSnapshot,
         query: ImageEmbeddingContent,
-        chunks: Sequence[DocumentChunk],
+        candidates: Sequence[UnitCandidate],
         top_k: int,
     ) -> ModelRerankResult:
+        """Rerank unit candidates directly; collapse to chunks afterwards.
+
+        Each unit is one rerank document, so candidate count == unit count ==
+        top_n is fully controlled. Over-limit lists are truncated by score with
+        a warning instead of failing the request.
+        """
+
         if (
             snapshot.resolved is None
             or not is_qwen3_vl_reranker(snapshot.resolved)
@@ -1045,79 +1099,71 @@ class KnowledgeRetrievalService:
                 "KB_MODEL_UNAVAILABLE",
                 "Image query requires qwen3-vl rerank",
             )
+
+        asset_ids = [c.asset_file_id for c in candidates if c.asset_file_id]
         asset_ids_by_kb: dict[uuid.UUID, list[str]] = {}
-        chunks_by_kb: dict[uuid.UUID, list[DocumentChunk]] = {}
-        for chunk in chunks:
-            raw_kb_id = (chunk.metadata or {}).get("knowledge_id")
+        for candidate in candidates:
+            if not candidate.asset_file_id:
+                continue
+            raw_kb_id = (candidate.chunk.metadata or {}).get("knowledge_id")
             try:
                 knowledge_id = uuid.UUID(str(raw_kb_id))
             except (TypeError, ValueError):
                 continue
-            chunks_by_kb.setdefault(knowledge_id, []).append(chunk)
-        for knowledge_id, kb_chunks in chunks_by_kb.items():
-            asset_ids_by_kb[knowledge_id] = collect_asset_file_ids(kb_chunks)
+            asset_ids_by_kb.setdefault(knowledge_id, []).append(candidate.asset_file_id)
         images: dict[str, ImageEmbeddingContent] = {}
-        for knowledge_id, asset_ids in asset_ids_by_kb.items():
+        for knowledge_id, kb_asset_ids in asset_ids_by_kb.items():
             images.update(
                 await resolve_storage_images_async(
                     runtime,
                     knowledge_id,
-                    asset_ids,
+                    list(dict.fromkeys(kb_asset_ids)),
                     phase="rerank",
                 )
             )
 
+        trimmed = select_units_for_rerank(
+            candidates,
+            max_text=_MAX_MULTIMODAL_RERANK_TEXT_VIEWS,
+            max_image=_MAX_MULTIMODAL_RERANK_IMAGE_VIEWS,
+        )
+
         views: list[RerankCandidateView] = []
-        text_view_count = 0
-        image_view_count = 0
-        for chunk_index, chunk in enumerate(chunks):
-            text = sanitized_retrieval_text(chunk)
-            if text:
+        kept: list[UnitCandidate] = []
+        for unit in trimmed:
+            if unit.kind is RetrievalUnitKind.TEXT:
+                text = unit.content
+                if not text.strip():
+                    continue
                 if num_tokens_from_string(text) > 8_000:
-                    raise KnowledgeError.from_code(
-                        "KB_MULTIMODAL_INPUT_LIMIT",
-                        "Rerank text view exceeds the token limit",
+                    logger.warning(
+                        "event=kb_multimodal_rerank_unit_skipped reason=text_token_limit "
+                        "unit_id=%s",
+                        unit.unit_id,
                     )
+                    continue
                 views.append(
                     RerankCandidateView(
-                        chunk_index=chunk_index,
+                        chunk_index=len(kept),
                         kind="text",
                         content=text,
                     )
                 )
-                text_view_count += 1
-            raw_ids = (chunk.metadata or {}).get("asset_file_ids")
-            chunk_image_index = 0
-            if isinstance(raw_ids, list):
-                for value in raw_ids:
-                    image = images.get(str(value))
-                    if image is None:
-                        continue
-                    views.append(
-                        RerankCandidateView(
-                            chunk_index=chunk_index,
-                            kind="image",
-                            image_index=chunk_image_index,
-                            content=image.data_uri,
-                        )
+                kept.append(unit)
+            else:
+                image = images.get(unit.asset_file_id or "")
+                if image is None:
+                    continue
+                views.append(
+                    RerankCandidateView(
+                        chunk_index=len(kept),
+                        kind="image",
+                        image_index=0,
+                        content=image.data_uri,
                     )
-                    chunk_image_index += 1
-                    image_view_count += 1
-        if (
-            text_view_count > _MAX_MULTIMODAL_RERANK_TEXT_VIEWS
-            or image_view_count > _MAX_MULTIMODAL_RERANK_IMAGE_VIEWS
-        ):
-            views = _select_multimodal_rerank_views(views)
-            retained_text_count = sum(view.kind == "text" for view in views)
-            logger.warning(
-                "event=kb_multimodal_rerank_views_trimmed "
-                "text_views_before=%s text_views_after=%s "
-                "image_views_before=%s image_views_after=%s",
-                text_view_count,
-                retained_text_count,
-                image_view_count,
-                len(views) - retained_text_count,
-            )
+                )
+                kept.append(unit)
+
         if not views:
             return ModelRerankResult(chunks=(), used_fallback=False)
 
@@ -1141,28 +1187,20 @@ class KnowledgeRetrievalService:
                 "Multimodal rerank failed",
             ) from exc
 
-        scores_by_chunk: dict[int, float] = {}
+        scored_units: list[UnitCandidate] = []
         for score in scores:
-            if score.input_index < 0 or score.input_index >= len(views):
+            if score.input_index < 0 or score.input_index >= len(kept):
                 raise KnowledgeError.from_code(
                     "KB_MULTIMODAL_RERANK_FAILED",
                     "Multimodal rerank returned an invalid index",
                 )
-            chunk_index = views[score.input_index].chunk_index
-            scores_by_chunk[chunk_index] = max(
-                scores_by_chunk.get(chunk_index, 0.0),
-                score.relevance_score,
+            unit = kept[score.input_index]
+            scored_units.append(
+                replace(unit, score=score.relevance_score)
             )
-        ranked = sorted(
-            scores_by_chunk.items(),
-            key=lambda item: (-item[1], item[0]),
-        )
-        result: list[DocumentChunk] = []
-        for chunk_index, score in ranked[:top_k]:
-            chunk = chunks[chunk_index].model_copy(deep=True)
-            chunk.metadata["score"] = score
-            result.append(chunk)
-        return ModelRerankResult(chunks=tuple(result), used_fallback=False)
+
+        collapsed = collapse_units_to_chunks(scored_units)
+        return ModelRerankResult(chunks=tuple(collapsed[:top_k]), used_fallback=False)
 
     @staticmethod
     def _seed_model_fallback_scores(

--- a/mem-knowledge/src/services/knowledge_retrieval_preparation.py
+++ b/mem-knowledge/src/services/knowledge_retrieval_preparation.py
@@ -332,6 +332,9 @@ class KnowledgeRetrievalPreparation:
                 if mode is RerankMode.RERANKING_MODEL
                 else None,
                 compatibility_fallback=mode is RerankMode.RERANKING_MODEL,
+                recompute_keywords=(
+                    target_count > 1 and mode is RerankMode.WEIGHTED_SCORE
+                ),
             )
         return RetrievalPreparation(
             targets=tuple(targets),
@@ -680,6 +683,8 @@ class KnowledgeRetrievalPreparation:
         if config is not None and config.rerank_mode is not None:
             return config.rerank_mode, cls._resolve_weights(config.rerank_weights), True
         if target_count == 1 and request.rerank_mode is not None:
+            return request.rerank_mode, cls._resolve_weights(request.rerank_weights), True
+        if target_count > 1 and request.rerank_mode is RerankMode.WEIGHTED_SCORE:
             return request.rerank_mode, cls._resolve_weights(request.rerank_weights), True
         return RerankMode.RERANKING_MODEL, cls._resolve_weights(None), False
 

--- a/mem-knowledge/src/services/knowledge_retrieval_preparation.py
+++ b/mem-knowledge/src/services/knowledge_retrieval_preparation.py
@@ -684,8 +684,6 @@ class KnowledgeRetrievalPreparation:
             return config.rerank_mode, cls._resolve_weights(config.rerank_weights), True
         if target_count == 1 and request.rerank_mode is not None:
             return request.rerank_mode, cls._resolve_weights(request.rerank_weights), True
-        if target_count > 1 and request.rerank_mode is RerankMode.WEIGHTED_SCORE:
-            return request.rerank_mode, cls._resolve_weights(request.rerank_weights), True
         return RerankMode.RERANKING_MODEL, cls._resolve_weights(None), False
 
     @classmethod

--- a/mem-knowledge/src/services/qa_export.py
+++ b/mem-knowledge/src/services/qa_export.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import aiofiles
 
+from ..rag.retrieval.elasticsearch_queries import build_chunk_record_filter
 from ..rag.vdb.field import Field
 from ..rag.vdb.pit_search import iter_async_search_after_hits
 
@@ -41,6 +42,7 @@ def _qa_query(kb_id: str, document_id: str | None = None) -> dict[str, Any]:
             }
         },
         {"term": {Field.KNOWLEDGE_ID.value: kb_id}},
+        build_chunk_record_filter(),
     ]
     if document_id is None:
         filters.append({"term": {"metadata.status": 1}})

--- a/mem-knowledge/src/services/qa_import_processing.py
+++ b/mem-knowledge/src/services/qa_import_processing.py
@@ -9,10 +9,15 @@ import time
 import uuid
 from dataclasses import dataclass
 
+from redbear_model import QWEN3_VL_EMBEDDING_DIMENSION, is_qwen3_vl_embedding
+from redbear_model.runtime import RedBearEmbeddings
+
 from ..models.owned import Document, Knowledge
 from ..models.references import Workspace
 from ..rag.models.chunk import DocumentChunk
+from ..rag.models.retrieval_unit import RetrievalUnitKind
 from ..rag.models.task_runtime import TaskModelFactory
+from ..rag.vdb.field import Field
 from ..rag.vdb.vector_store import TaskVectorStore
 from ..runtime import ProcessRuntime
 from ..tasks.observability import BusinessOutcome, TaskRun
@@ -318,10 +323,15 @@ def process_qa_import(
         error_code = "KB_QA_MODEL_INIT_FAILED"
         try:
             with run.stage("resolve_embedding"):
-                embeddings = TaskModelFactory(runtime).create_embeddings(
+                embedding_config = TaskModelFactory(runtime).resolve_embedding(
                     snapshot.embedding_id,
                     snapshot.tenant_id,
                 )
+                embeddings = RedBearEmbeddings(
+                    embedding_config,
+                    client_pool=runtime.model_runtime.pool,
+                )
+                multimodal = is_qwen3_vl_embedding(embedding_config)
         except Exception:
             raise _SafeQAImportError("QA model initialization failed") from None
 
@@ -332,6 +342,8 @@ def process_qa_import(
                     runtime.elasticsearch.sync_client(),
                     normalized_kb_id,
                     embeddings,
+                    structured_multimodal=multimodal,
+                    embedding_dimension=QWEN3_VL_EMBEDDING_DIMENSION if multimodal else None,
                 )
             sort_id = 0
             if not clear_parse_task:
@@ -358,7 +370,17 @@ def process_qa_import(
                 prepared_batches.append(
                     vector_store.prepare_chunks(chunks[start : start + batch_size])
                 )
-            if sum(batch.chunk_count for batch in prepared_batches) != len(chunks):
+            prepared_count = (
+                sum(
+                    action["_source"].get(Field.UNIT_KIND.value)
+                    == RetrievalUnitKind.CHUNK_RECORD.value
+                    for batch in prepared_batches
+                    for action in batch.actions
+                )
+                if multimodal
+                else sum(batch.chunk_count for batch in prepared_batches)
+            )
+            if prepared_count != len(chunks):
                 raise RuntimeError("Prepared chunk count does not match input count")
             if clear_parse_task:
                 with run.stage("delete_old_chunks"):

--- a/mem-knowledge/uv.lock
+++ b/mem-knowledge/uv.lock
@@ -719,6 +719,12 @@ wheels = [
 ]
 
 [[package]]
+name = "jieba"
+version = "0.42.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/cb/18eeb235f833b726522d7ebed54f2278ce28ba9438e3135ab0278d9792a2/jieba-0.42.1.tar.gz", hash = "sha256:055ca12f62674fafed09427f176506079bc135638a14e23e25be909131928db2", size = 19214172, upload-time = "2020-01-20T14:27:23.5Z" }
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1083,6 +1089,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "html5lib" },
     { name = "httpx" },
+    { name = "jieba" },
     { name = "jinja2" },
     { name = "json-repair" },
     { name = "kombu" },
@@ -1130,6 +1137,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.119,<1" },
     { name = "html5lib", specifier = "==1.1" },
     { name = "httpx", specifier = ">=0.28,<1" },
+    { name = "jieba", specifier = "==0.42.1" },
     { name = "jinja2", specifier = ">=3.1,<4" },
     { name = "json-repair", specifier = "==0.53.0" },
     { name = "kombu", specifier = "==5.5.4" },


### PR DESCRIPTION
## Summary

Multimodal knowledge bases previously stored one fused vector per chunk. This change stores authoritative chunk records plus independently embedded text/image retrieval units, then returns chunk bodies after recall and reranking. Plain-text knowledge bases retain their existing storage layout.

- Add stable unit IDs, multimodal unit mappings, vector/full-text recall, score collapse and bounded multimodal rerank inputs. Use non-indexed 2048-dimensional vectors with script_score for the current Elasticsearch compatibility constraints.
- Align API-created indexes with worker-created indexes. Read authoritative records for chunk lists, single-chunk reads, Evidence Graph sources and QA exports, retaining legacy-record compatibility in graph/export reads.
- Reuse unchanged vectors during content edits and preserve stored vision_text and image assets. Prepare changed text embeddings before writing, then remove obsolete units only after successful upserts.
- Preserve ranking scores through final parent resolution, restore image/QA return bodies with one batched record lookup per nonempty unit recall, and keep retrieval text separate from display Markdown.
- Write multimodal QA imports as retrieval units while retaining business QA counts.

- Preserve KB-scoped unit identity through local and global model reranking. Merge duplicate channel hits for the same unit; retain all eligible units of selected return chunks, then collapse for final output. Weighted fusion still aggregates channels per source chunk, while parent targets share final result slots.

## Scope and compatibility

21 topic commits across 14 mem-knowledge backend files, rebased onto develop. No frontend, deployment, database model, credential or local-agent files are included. Tests remain local per repository policy.

No external API Key route expansion or request/response schema changes. Returned image/QA bodies are corrected without allowing the edit API to modify or regenerate vision_text. Multimodal retrieval behavior changes as described above; unchanged schemas do not imply that legacy multimodal indexes are migration-free.

## Risks and deferred work

This is a draft for review. The following known issues were explicitly left outside the selected fixes:

- Concurrent edits/deletes can race with stable-ID upserts and stale-unit cleanup. Bulk writes are not cross-document transactions.
- Limiting unit hits before chunk collapse can return fewer distinct chunks than requested.
- Existing legacy multimodal indexes require a separately coordinated migration/rebuild; this PR does not migrate existing indexes or reimport historical QA automatically.

Unit writes increase document and embedding counts. Returning authoritative bodies adds a batched Elasticsearch lookup. No live Elasticsearch, model-provider, deployment or latency validation was performed.

## Validation

- 105 focused local cases passed after the latest fix, including unit identity, sibling units, local/global image reranking, parent result slots, weighted fusion, fallback, ordinary-text retrieval, authoritative bodies, QA import, mapping parity and editing behavior.
- Local test fixtures now use complete RetrievalParams and ResolvedModelConfig objects; the earlier fixture errors are resolved. Tests remain local per repository policy.
- Ruff passed for the changed production files and relevant local tests.
- `python scripts/check_import_boundaries.py` and `git diff --check` passed.
- Independent review identified a parent-slot grouping regression; a failing regression test was added and the issue fixed. Follow-up review found no additional issue in that correction.
- No live Elasticsearch, model-provider or deployment verification was performed.

## Sourcery 总结

在保留纯文本存储和现有 API 兼容性的同时，新增基于单元的多模态检索功能。

新功能：
- 将多模态分块存储为可独立检索的文本单元和图像单元，并为其提供稳定标识以及权威的分块记录。
- 支持多模态向量检索和全文召回，并通过基于单元的重排序、通道融合，将结果合并回分块级别。
- 将多模态 QA 导入内容写入检索单元，同时保留现有的 QA 数量统计。

错误修复：
- 在多模态分块列表、检索结果、图谱来源和 QA 导出中，正确返回权威的分块内容和分数。
- 编辑分块时保留图像资源、视觉文本和未更改的向量，同时安全地替换已更改的检索单元。
- 在最终排序后解析父分块，同时不丢失结果顺序或分数。

增强功能：
- 使 API 创建的多模态索引与 worker 创建的索引布局保持一致，并兼容旧版分块记录。
- 将检索内容与展示用 Markdown 分离，并根据单元类型限制多模态重排序输入。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

引入基于单元的多模态检索，同时保留纯文本存储和现有 API 行为。

新功能：
- 为多模态知识库添加可独立检索、具有稳定标识的文本单元和图像单元。
- 支持多模态向量召回和全文召回、面向单元的重排序、通道融合，以及分块级结果折叠。
- 将多模态 QA 导入内容存储为检索单元，同时保留现有 QA 计数。

错误修复：
- 在列表、检索、图谱来源、QA 导出和最终父级解析过程中，返回权威的分块正文并保留排序分数。
- 编辑分块时保留未发生变化的嵌入、视觉文本和图像资源，同时安全替换已变更的检索单元。
- 恢复图像和 QA 结果正文，避免将检索文本与展示内容混淆。

增强功能：
- 对齐 API 创建和 Worker 创建的多模态索引布局，同时保持与旧版分块记录的兼容性。
- 对多模态重排序应用有界的文本和图像输入，并在本地排序和全局排序过程中保留知识库范围内的单元标识。

构建：
- 添加 jieba 依赖，用于加权关键词评分。

测试：
- 扩展针对单元标识、多模态排序、父级解析、权威记录、QA 导入、索引一致性和编辑行为的专项测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce unit-based multimodal retrieval while preserving plain-text storage and existing API behavior.

New Features:
- Add independently retrievable text and image units with stable identities for multimodal knowledge bases.
- Support multimodal vector and full-text recall, unit-aware reranking, channel fusion, and chunk-level result collapsing.
- Store multimodal QA imports as retrieval units while preserving existing QA counts.

Bug Fixes:
- Return authoritative chunk bodies and preserve ranking scores across listings, retrieval, graph sources, QA exports, and final parent resolution.
- Preserve unchanged embeddings, vision text, and image assets during chunk edits while safely replacing changed retrieval units.
- Restore image and QA result bodies without conflating retrieval text with display content.

Enhancements:
- Align API-created and worker-created multimodal index layouts while retaining compatibility with legacy chunk records.
- Apply bounded text and image inputs to multimodal reranking and preserve knowledge-base-scoped unit identity through local and global ranking.

Build:
- Add jieba as a dependency for weighted keyword scoring.

Tests:
- Expand focused coverage for unit identity, multimodal ranking, parent resolution, authoritative records, QA import, index parity, and editing behavior.

</details>

</details>