### PR TITLE
fix(rag): tolerate empty Excel fill styles

### DIFF
--- a/mem-knowledge/src/rag/chunk/parser/excel.py
+++ b/mem-knowledge/src/rag/chunk/parser/excel.py
@@ -1,18 +1,26 @@
 import copy
 import csv
 import io
+import logging
 from dataclasses import dataclass
 from datetime import date, datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Any
+from zipfile import ZipFile
 
 import xlrd
+from lxml import etree
 from openpyxl import Workbook, load_workbook
 from openpyxl.utils import get_column_letter
 
 from ..tokenization import add_positions, find_codec, set_chunk_content
 from .base import DocumentParser
+
+LOGGER = logging.getLogger(__name__)
+_FILL_TYPE_ERROR = "expected <class 'openpyxl.styles.fills.Fill'>"
+_STYLES_PATH = "xl/styles.xml"
+_SPREADSHEET_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 
 EMPTY_MARKERS = {"", "/", "none", "null", "nan", "-"}
 
@@ -123,8 +131,59 @@ class StructuredExcelParser(DocumentParser):
             return self._csv_workbook(binary)
         if suffix == ".xls":
             return self._xls_workbook(binary)
-        stream = BytesIO(binary)
-        return load_workbook(stream, data_only=True)
+        try:
+            return load_workbook(BytesIO(binary), data_only=True)
+        except TypeError as exc:
+            if str(exc) != _FILL_TYPE_ERROR:
+                raise
+            repaired = self._repair_empty_fills(binary)
+            if repaired is None:
+                raise
+            repaired_binary, count = repaired
+            LOGGER.warning(
+                "Retrying Excel load after normalizing empty fills: filename=%s count=%d",
+                filename, count,
+            )
+            return load_workbook(BytesIO(repaired_binary), data_only=True)
+
+    @staticmethod
+    def _repair_empty_fills(binary: bytes) -> tuple[bytes, int] | None:
+        """Normalize only empty fill entries, preserving their IDs and all other members."""
+        with ZipFile(BytesIO(binary)) as source:
+            if _STYLES_PATH not in source.namelist():
+                return None
+            root = etree.fromstring(
+                source.read(_STYLES_PATH),
+                parser=etree.XMLParser(resolve_entities=False, no_network=True),
+            )
+            fills = root.find(f"{{{_SPREADSHEET_NS}}}fills")
+            if fills is None:
+                return None
+            count = 0
+            for fill in fills:
+                if (
+                    fill.tag == f"{{{_SPREADSHEET_NS}}}fill"
+                    and not fill.attrib
+                    and len(fill) == 0
+                    and not (fill.text or "").strip()
+                ):
+                    etree.SubElement(
+                        fill, f"{{{_SPREADSHEET_NS}}}patternFill", patternType="none"
+                    )
+                    count += 1
+            if not count:
+                return None
+            output = BytesIO()
+            with ZipFile(output, "w") as target:
+                target.comment = source.comment
+                for member in source.infolist():
+                    data = (
+                        etree.tostring(root, encoding="utf-8", xml_declaration=True)
+                        if member.filename == _STYLES_PATH
+                        else source.read(member)
+                    )
+                    target.writestr(member, data)
+            return output.getvalue(), count
 
     def _csv_workbook(self, binary: bytes):
         workbook = Workbook()


### PR DESCRIPTION
## Summary
Some XLSX files contain empty `<fill/>` entries in `xl/styles.xml`. Openpyxl rejects them with `TypeError: expected <class 'openpyxl.styles.fills.Fill'>`, stopping document parsing before vectorization.

Retry workbook loading once for that specific exception after adding a no-fill pattern to empty fill entries in an in-memory copy. Preserve fill IDs, all other ZIP member contents, and the original uploaded file. Normal files keep the existing loading path; unrelated errors and retry failures propagate.

## Scope and risk
Only the new knowledge service Excel parser changes. Malformed empty fills are interpreted as no fill; other styles, including date formats, remain intact. Exceptional files incur one additional in-memory ZIP rebuild and workbook load. No route, authentication, schema, or external API Key interface/permission changes. Existing API Key document imports benefit from the same parser compatibility fix.

## Validation
- `uv run --locked pytest -c pyproject.toml ../tests/mem_knowledge/parser/test_excel_empty_fills.py -q --tb=short`: 8 passed, including the original failing workbook, successful chunk parsing, date/value preservation, unchanged non-style ZIP contents, error gating, and single retry.
- The failing file and malformed-style fixture reproduced the original exception before the fix.
- Targeted Ruff, import-boundary checks, and `git diff --check` passed.
- Regression tests and source workbook remain local under repository policy. The original workbook still emits a separate nonfatal missing-default-style warning.
- No deployment or live worker reprocessing performed.

## Sourcery 总结

增强 Excel 解析对格式错误的空填充样式的容错能力，同时保留有效工作簿和无关错误的现有行为。

错误修复：
- 允许包含空填充样式条目的 Excel 文档在工作簿加载期间成功解析和向量化，而不是失败。

改进：
- 保留填充 ID、非样式 ZIP 内容以及原始上传的工作簿，仅在内存中的重试过程中规范化格式错误的空填充样式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make Excel parsing resilient to malformed empty fill styles while preserving existing behavior for valid workbooks and unrelated errors.

Bug Fixes:
- Allow Excel documents containing empty fill style entries to be parsed and vectorized instead of failing during workbook loading.

Enhancements:
- Preserve fill IDs, non-style ZIP contents, and the original uploaded workbook while normalizing only malformed empty fills in an in-memory retry.

</details>